### PR TITLE
Add vars for rancher

### DIFF
--- a/control-plane/main.tf
+++ b/control-plane/main.tf
@@ -92,4 +92,6 @@ module "k3s" {
   rancher_password            = random_password.rancher_password.result
   rancher_image               = var.rancher_image
   rancher_image_tag           = var.rancher_image_tag
+  server_instance_type        = var.rancher_instance_type
+  server_node_count           = var.rancher_node_count
 }

--- a/control-plane/variables.tf
+++ b/control-plane/variables.tf
@@ -80,3 +80,8 @@ variable "rancher_image_tag" {
   type    = string
   default = "master-head"
 }
+
+variable "rancher_node_count" {
+  type    = number
+  default = 1
+}


### PR DESCRIPTION
Added variables to pass to aws-k3s module that configure
number of rancher nodes and instance size.