### PR TITLE
Add shared docker overlay network using consul discovery

### DIFF
--- a/cluster-with-nodes/files/server_userdata.tmpl
+++ b/cluster-with-nodes/files/server_userdata.tmpl
@@ -17,6 +17,13 @@ write_files:
       sleep 2
       i+=1
     done
+- path: /etc/docker/daemon.json
+  permissions: '0770'
+  content: |
+    {
+    "cluster-store": "consul://127.0.0.1:8500",
+    "cluster-advertise": "eth0:2376"
+    }
 runcmd:
 - echo "net.ipv4.ip_local_port_range = 15000 61000" >> /etc/sysctl.conf
 - echo "fs.file-max = 12000500" >> /etc/sysctl.conf
@@ -42,13 +49,24 @@ runcmd:
 - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 - add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 - apt-get update
+- wget https://releases.hashicorp.com/consul/1.7.1/consul_1.7.1_linux_amd64.zip -O /root/consul.zip
+- apt-get install -y unzip
+- unzip /root/consul.zip -d /root
+- mkdir -p /var/consul
+- apt-get install -y screen
+- screen -dmS consul /root/consul agent -server -bootstrap -data-dir=/var/consul -client=0.0.0.0 -allow-write-http-from=127.0.0.1/32 -allow-write-http-from=${vpc_cidr}
 - apt-get -y install docker-ce
+- systemctl enable docker
+- systemctl start docker
+- docker network create -d overlay k3d-k3s-cluster --label app=k3d --label cluster=k3s-cluster --subnet "${docker_overlay_cidr}"
 # - DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
-- curl -s https://raw.githubusercontent.com/rancher/k3d/master/install.sh | bash
+#- curl -s https://raw.githubusercontent.com/rancher/k3d/master/install.sh | bash
+- wget https://github.com/Oats87/k3d/releases/download/network1/k3d-linux-amd64 -O /usr/local/bin/k3d
+- chmod +x /usr/local/bin/k3d
 - curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
 - chmod +x ./kubectl
 - mv ./kubectl /usr/local/bin/kubectl
 - sleep 5
-- k3d create -n "k3s-cluster" --api-port "$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4):6443" --server-arg --token="${k3s_token}" --server-arg --advertise-address="$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)" --image="${install_k3s_version}"
+- k3d create -n "k3s-cluster" --api-port "$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4):6443" --server-arg --token="${k3s_token}" --server-arg --advertise-address="$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)" --image="${install_k3s_version}" --server-arg --flannel-iface=eth0 --agent-arg --flannel-iface=eth0
 - /usr/local/bin/k3svalidation.sh
 - KUBECONFIG=$(k3d get-kubeconfig --name=k3s-cluster) ${registration_commands[0]}

--- a/cluster-with-nodes/main.tf
+++ b/cluster-with-nodes/main.tf
@@ -38,7 +38,9 @@ resource "aws_spot_instance_request" "k3s-server" {
     {
       k3s_token             = local.k3s_token,
       install_k3s_version   = local.install_k3s_version,
-      registration_commands = rancher2_cluster.k3s[*].cluster_registration_token[0].command
+      registration_commands = rancher2_cluster.k3s[*].cluster_registration_token[0].command,
+      vpc_cidr              = data.aws_vpc.default.cidr_block
+      docker_overlay_cidr   = var.docker_overlay_cidr
     }
   )
 
@@ -66,4 +68,5 @@ module "downstream-k3s-nodes" {
   k3s_token = local.k3s_token
   k3s_endpoint = "https://${aws_spot_instance_request.k3s-server.private_ip}:6443"
   install_k3s_version = local.install_k3s_version
+  consul_store = aws_spot_instance_request.k3s-server.private_ip
 }

--- a/cluster-with-nodes/modules/downstream-k3s-nodes/files/worker_userdata.tmpl
+++ b/cluster-with-nodes/modules/downstream-k3s-nodes/files/worker_userdata.tmpl
@@ -1,6 +1,14 @@
 #cloud-config
 ssh_authorized_keys: 
   - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDaitXW9CBM/yxEhVaBQ9WEB8KEdwbzlMk6M2URfbr07mA9Rk3ssWf2hS3RMwF76rasRLmrjsge1Q9cc8uck722vs8qCpwz/aMnsHF8kfnifkv3JKgfYCTkVzbsW7HzNmmkbsBVPS2tlVDpG+cHQNwZMgo1MGVJqAvPnrKlLzSj/XVeBKYV8a7/GLwrJTiXegitkyE3i1L42aMwzGDwEDnKkFBYW1JXXim0j97ztWy8YaScuptqd9WJ5NfHgUGfhFSYKlEX+FP5x0oyLVgGRmoUh7NellALQ9mWW+tJgSd7oWPoeJtHLAVMoiX02w1OtBUOFq1s0IJ9nDdU/I9v+grP chriskim@Endeavor
+write_files:
+- path: /etc/docker/daemon.json
+  permissions: '0770'
+  content: |
+    {
+    "cluster-store": "consul://${consul_store}:8500",
+    "cluster-advertise": "eth0:2376"
+    }
 runcmd:
 - echo "net.ipv4.ip_local_port_range = 15000 61000" >> /etc/sysctl.conf
 - echo "fs.file-max = 12000500" >> /etc/sysctl.conf
@@ -28,6 +36,9 @@ runcmd:
 - apt-get update
 - apt-get -y install docker-ce
 # - DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
-- curl -s https://raw.githubusercontent.com/rancher/k3d/master/install.sh | bash
+#- curl -s https://raw.githubusercontent.com/rancher/k3d/master/install.sh | bash
+- wget https://github.com/Oats87/k3d/releases/download/network1/k3d-linux-amd64 -O /usr/local/bin/k3d
+- chmod +x /usr/local/bin/k3d
 - sleep 5
-- k3d add-node -n "k3s-cluster-i${current_instance}o" --k3s-token="${k3s_token}" --k3s "${k3s_endpoint}" --count "${agents_per_node}" --image="${install_k3s_version}"
+- while true; do curl -sk ${k3s_endpoint}/ping 2>&1 | grep -q "pong"; if [ $? != 0 ]; then echo "notreadyyet"; sleep 5; continue; fi; break; done; echo "yep";
+- k3d add-node -n "k3s-cluster-i${current_instance}" --network "k3d-k3s-cluster" --k3s-token="${k3s_token}" --k3s "${k3s_endpoint}" --count "${agents_per_node}" --image="${install_k3s_version}" --arg --flannel-iface=eth0

--- a/cluster-with-nodes/modules/downstream-k3s-nodes/main.tf
+++ b/cluster-with-nodes/modules/downstream-k3s-nodes/main.tf
@@ -13,7 +13,8 @@ resource "aws_spot_instance_request" "k3s-worker" {
       agents_per_node       = var.k3s_agents_per_node,
       k3s_endpoint          = var.k3s_endpoint,
       k3s_token             = var.k3s_token,
-      install_k3s_version   = var.install_k3s_version
+      install_k3s_version   = var.install_k3s_version,
+      consul_store          = var.consul_store
     }
   )
 

--- a/cluster-with-nodes/modules/downstream-k3s-nodes/variables.tf
+++ b/cluster-with-nodes/modules/downstream-k3s-nodes/variables.tf
@@ -17,3 +17,5 @@ variable "install_k3s_version" {}
 variable "prefix" {}
 variable "spot_price" {}
 variable "ami_id" {}
+
+variable "consul_store" {}

--- a/cluster-with-nodes/terraform.tfvars.example
+++ b/cluster-with-nodes/terraform.tfvars.example
@@ -1,0 +1,10 @@
+k3s_agents_per_node=20
+ec2_instances_per_cluster=1
+server_instance_type="t2.medium"
+worker_instance_type="t2.medium"
+rancher_api_url="<rancher-url>"
+rancher_token_key="<rancher-token>"
+k3s_token="<chosen-k3s-token>"
+server_instance_max_price="1.25"
+worker_instance_max_price="1.25"
+docker_overlay_cidr="10.0.0.0/8"

--- a/cluster-with-nodes/variables.tf
+++ b/cluster-with-nodes/variables.tf
@@ -1,5 +1,5 @@
 /*
-  The k3s agents per node and ec2_instances_per_cluster (and number of clusters) are used together to determine total number of nodes. If you have 3 desired clusters, with 15 k3s agents per node, across 2 instances
+  The k3s agents per node and ec2_instances_per_cluster are used together to determine total number of nodes
 */ 
 
 variable "k3s_agents_per_node" {
@@ -25,7 +25,6 @@ variable "worker_instance_type" {
   description = "Instance type to use for k3s workers"
 }
 
-
 variable "k3s_server_args" {
   type        = string
   default     = ""
@@ -45,4 +44,9 @@ variable "rancher_token_key" {
 variable "k3s_token" {
   type        = string
   description = "k3s token"
+}
+
+variable "docker_overlay_cidr" {
+  type        = string
+  description = "docker overlay network cidr i.e. 10.0.0.0/8"
 }


### PR DESCRIPTION
This adds functionality underneath to "mesh" together the underlying K3d hosts using Docker's capability to create an overlay network between containers. There is also a minor enhancement to `k3d` that was made (to allow specifying a custom network) and this is updated to use that new logic.