### PR TITLE
Update cert manager install

### DIFF
--- a/control-plane/modules/aws-k3s/files/rancher-install.sh
+++ b/control-plane/modules/aws-k3s/files/rancher-install.sh
@@ -5,15 +5,13 @@ kubectl taint nodes $node monitoring=yes:NoSchedule
 kubectl label nodes $node monitoring=yes
 
 %{ if install_certmanager ~}
-kubectl create namespace cert-manager
-kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
-sleep 5
 kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v${certmanager_version}/cert-manager.yaml
 
-until [ "$(kubectl get pods --namespace cert-manager |grep Running|wc -l)" = "3" ]; do
+until [ "$(kubectl get pods --namespace cert-manager | grep Running | wc -l)" = "3" ]; do
   sleep 2
 done
 %{ endif ~}
+
 %{ if install_rancher ~}
 cat <<EOF > /var/lib/rancher/k3s/server/manifests/rancher.yaml
 ---


### PR DESCRIPTION
New versions of cert-manager don't require the NS or the label to be applied anymore. 