### PR TITLE
add modules for rke1 control-plane + rancher setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ kube-config.yaml
 .*tfkubeconfig
 *.zip
 *.log
+*logs.txt
+.*tf-kubeconfig

--- a/control-plane/README.md
+++ b/control-plane/README.md
@@ -10,26 +10,26 @@ Initialize terraform default workspace. This only needs to be run once to create
 ```bash
 cd control-plane
 terraform init
-``` 
+```
 AWS credentials are required so they can either be set in the env or on the command line before running the below commands
 
 Create k3s cluster with **mariadb** data store:
 
 ```bash
 terraform apply
-``` 
+```
 Creating the cluster resources takes about 10-15 minutes. After successfully running `apply` terraform will output information needed to connect to the rancher server.
 
 ### Destroying cluster resources
 
 ```bash
 terraform destroy
-``` 
+```
 
 Destroying cluster resources takes about 10-15 minutes.
 
 ### Configuration:
-Configuration changes should be done in `terraform.tfvars` to override default variable settings in `variables.tf`. The format of the `terraform.tfvars` file must be in done with key/value pairs. 
+Configuration changes should be done in `terraform.tfvars` to override default variable settings in `variables.tf`. The format of the `terraform.tfvars` file must be in done with key/value pairs.
 
 #### Example terraform.tfvars file:
 ```
@@ -59,3 +59,125 @@ kubectl port-forward -n cattle-monitoring-system deployment/rancher-monitoring-g
 ```
 Then go to `http://127.0.0.1:8443` in a browser to connect back to the Grafana UI.
 The port `8443` can be adjusted as need for your local system.
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.71.0 |
+| <a name="provider_rancher2.admin"></a> [rancher2.admin](#provider\_rancher2.admin) | 1.22.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_aws_infra"></a> [aws\_infra](#module\_aws\_infra) | ./modules/aws-infra | n/a |
+| <a name="module_db"></a> [db](#module\_db) | terraform-aws-modules/rds/aws | >= 3.2 |
+| <a name="module_generate_kube_config"></a> [generate\_kube\_config](#module\_generate\_kube\_config) | ./modules/generate-kube-config | n/a |
+| <a name="module_install_common"></a> [install\_common](#module\_install\_common) | ./modules/install-common | n/a |
+| <a name="module_k3s"></a> [k3s](#module\_k3s) | ./modules/aws-k3s | n/a |
+| <a name="module_rke1"></a> [rke1](#module\_rke1) | ./modules/rke1 | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_security_group.database](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.database_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [rancher2_app_v2.rancher_monitoring](https://registry.terraform.io/providers/rancher/rancher2/latest/docs/resources/app_v2) | resource |
+| [rancher2_catalog_v2.rancher_charts_custom](https://registry.terraform.io/providers/rancher/rancher2/latest/docs/resources/catalog_v2) | resource |
+| [random_password.rancher_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [random_pet.identifier](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_route53_zone.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+| [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
+| [aws_subnet_ids.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | n/a | `string` | `"us-west-2"` | no |
+| <a name="input_byo_certs_bucket_path"></a> [byo\_certs\_bucket\_path](#input\_byo\_certs\_bucket\_path) | Optional: String that defines the path on the S3 Bucket where your certs are stored. NOTE: assumes certs are stored in a tarball within a folder below the top-level bucket e.g.: my-bucket/certificates/my\_certs.tar.gz. Certs should be stored within a single folder, certs nested in sub-folders will not be handled | `string` | `""` | no |
+| <a name="input_certmanager_version"></a> [certmanager\_version](#input\_certmanager\_version) | Version of cert-manager to install | `string` | `"1.4.2"` | no |
+| <a name="input_db_allocated_storage"></a> [db\_allocated\_storage](#input\_db\_allocated\_storage) | n/a | `number` | `100` | no |
+| <a name="input_db_engine"></a> [db\_engine](#input\_db\_engine) | n/a | `string` | `"mariadb"` | no |
+| <a name="input_db_engine_version"></a> [db\_engine\_version](#input\_db\_engine\_version) | n/a | `string` | `"10.5"` | no |
+| <a name="input_db_instance_class"></a> [db\_instance\_class](#input\_db\_instance\_class) | n/a | `string` | `"db.t3.medium"` | no |
+| <a name="input_db_iops"></a> [db\_iops](#input\_db\_iops) | n/a | `number` | `1000` | no |
+| <a name="input_db_name"></a> [db\_name](#input\_db\_name) | n/a | `string` | `"rancher"` | no |
+| <a name="input_db_password"></a> [db\_password](#input\_db\_password) | Password string for database, must be >= 8 characters. Only printable ASCII characters are allowed, the following are not allowed: '/@" ' | `string` | `"rancher12345"` | no |
+| <a name="input_db_port"></a> [db\_port](#input\_db\_port) | n/a | `number` | `3306` | no |
+| <a name="input_db_skip_final_snapshot"></a> [db\_skip\_final\_snapshot](#input\_db\_skip\_final\_snapshot) | n/a | `bool` | `true` | no |
+| <a name="input_db_storage_encrypted"></a> [db\_storage\_encrypted](#input\_db\_storage\_encrypted) | n/a | `bool` | `false` | no |
+| <a name="input_db_storage_type"></a> [db\_storage\_type](#input\_db\_storage\_type) | n/a | `string` | `"io1"` | no |
+| <a name="input_db_subnet_group_name"></a> [db\_subnet\_group\_name](#input\_db\_subnet\_group\_name) | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | `string` | `null` | no |
+| <a name="input_db_username"></a> [db\_username](#input\_db\_username) | n/a | `string` | `"rancher"` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | n/a | `string` | `""` | no |
+| <a name="input_install_certmanager"></a> [install\_certmanager](#input\_install\_certmanager) | Boolean that defines whether or not to install Cert-Manager | `bool` | `true` | no |
+| <a name="input_install_docker_version"></a> [install\_docker\_version](#input\_install\_docker\_version) | Version of Docker to install | `string` | `"20.10"` | no |
+| <a name="input_install_k3s_version"></a> [install\_k3s\_version](#input\_install\_k3s\_version) | Version of K3S to install (github release tag without the 'v') | `string` | `"1.20.10+k3s1"` | no |
+| <a name="input_install_k8s_version"></a> [install\_k8s\_version](#input\_install\_k8s\_version) | Version of K8s to install | `string` | `"1.21.7-rancher1-1"` | no |
+| <a name="input_install_monitoring"></a> [install\_monitoring](#input\_install\_monitoring) | Boolean that defines whether or not to install rancher-monitoring | `bool` | `true` | no |
+| <a name="input_install_rancher"></a> [install\_rancher](#input\_install\_rancher) | Boolean that defines whether or not to install Rancher | `bool` | `true` | no |
+| <a name="input_k8s_distribution"></a> [k8s\_distribution](#input\_k8s\_distribution) | The K8s distribution to use for setting up Rancher (k3s or rke1) | `string` | n/a | yes |
+| <a name="input_letsencrypt_email"></a> [letsencrypt\_email](#input\_letsencrypt\_email) | LetsEncrypt email address to use | `string` | `"none@none.com"` | no |
+| <a name="input_monitoring_chart_values_path"></a> [monitoring\_chart\_values\_path](#input\_monitoring\_chart\_values\_path) | Path to custom values.yaml for rancher-monitoring | `string` | `null` | no |
+| <a name="input_monitoring_version"></a> [monitoring\_version](#input\_monitoring\_version) | Version of Monitoring v2 to install - Do not include the v prefix. | `string` | n/a | yes |
+| <a name="input_private_ca_file"></a> [private\_ca\_file](#input\_private\_ca\_file) | Optional: String that defines the name of the private CA .pem file in the specified S3 bucket's cert tarball | `string` | `""` | no |
+| <a name="input_r53_domain"></a> [r53\_domain](#input\_r53\_domain) | DNS domain for Route53 zone (defaults to domain if unset) | `string` | `""` | no |
+| <a name="input_rancher_chart"></a> [rancher\_chart](#input\_rancher\_chart) | Helm chart to use for Rancher install | `string` | `"stable"` | no |
+| <a name="input_rancher_charts_branch"></a> [rancher\_charts\_branch](#input\_rancher\_charts\_branch) | The github branch for the desired Rancher chart version | `string` | `"release-v2.6"` | no |
+| <a name="input_rancher_charts_repo"></a> [rancher\_charts\_repo](#input\_rancher\_charts\_repo) | The URL for the desired Rancher charts | `string` | `""` | no |
+| <a name="input_rancher_image"></a> [rancher\_image](#input\_rancher\_image) | n/a | `string` | `"rancher/rancher"` | no |
+| <a name="input_rancher_image_tag"></a> [rancher\_image\_tag](#input\_rancher\_image\_tag) | Rancher image tag to install, this can differ from rancher\_version which is the chart being used to install Rancher | `string` | `"master-head"` | no |
+| <a name="input_rancher_instance_type"></a> [rancher\_instance\_type](#input\_rancher\_instance\_type) | instance type used for the rancher servers | `string` | `"m5.xlarge"` | no |
+| <a name="input_rancher_node_count"></a> [rancher\_node\_count](#input\_rancher\_node\_count) | n/a | `number` | `1` | no |
+| <a name="input_rancher_password"></a> [rancher\_password](#input\_rancher\_password) | Password to set for admin user during bootstrap of Rancher Server, if not set random password will be generated | `string` | `""` | no |
+| <a name="input_rancher_version"></a> [rancher\_version](#input\_rancher\_version) | Version of Rancher to install - Do not include the v prefix. | `string` | n/a | yes |
+| <a name="input_random_prefix"></a> [random\_prefix](#input\_random\_prefix) | Prefix to be used with random name generation | `string` | `"rancher"` | no |
+| <a name="input_s3_bucket_region"></a> [s3\_bucket\_region](#input\_s3\_bucket\_region) | Optional: String that defines the AWS region of the S3 Bucket that stores the desired certs. Required if 'byo\_certs\_bucket\_path' is set. Defaults to the aws\_region if not set | `string` | `""` | no |
+| <a name="input_s3_instance_profile"></a> [s3\_instance\_profile](#input\_s3\_instance\_profile) | Optional: String that defines the name of the IAM Instance Profile that grants S3 access to the EC2 instances. Required if 'byo\_certs\_bucket\_path' is set | `string` | `""` | no |
+| <a name="input_sensitive_token"></a> [sensitive\_token](#input\_sensitive\_token) | Boolean that determines if the module should treat the generated Rancher Admin API Token as sensitive in the output. | `bool` | `true` | no |
+| <a name="input_server_k3s_exec"></a> [server\_k3s\_exec](#input\_server\_k3s\_exec) | exec args to pass to k3s server | `string` | `null` | no |
+| <a name="input_ssh_key_path"></a> [ssh\_key\_path](#input\_ssh\_key\_path) | Path to the private SSH key file to be used for connecting to the node(s) | `string` | `null` | no |
+| <a name="input_ssh_keys"></a> [ssh\_keys](#input\_ssh\_keys) | SSH keys to inject into Rancher instances | `list(any)` | `[]` | no |
+| <a name="input_tls_cert_file"></a> [tls\_cert\_file](#input\_tls\_cert\_file) | Optional: String that defines the name of the TLS Certificate file in the specified S3 bucket's cert tarball. Required if 'byo\_certs\_bucket\_path' is set | `string` | `""` | no |
+| <a name="input_tls_key_file"></a> [tls\_key\_file](#input\_tls\_key\_file) | Optional: String that defines the name of the TLS Key file in the specified S3 bucket's cert tarball. Required if 'byo\_certs\_bucket\_path' is set | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_certmanager_version"></a> [certmanager\_version](#output\_certmanager\_version) | n/a |
+| <a name="output_db_engine_version"></a> [db\_engine\_version](#output\_db\_engine\_version) | n/a |
+| <a name="output_db_instance_availability_zone"></a> [db\_instance\_availability\_zone](#output\_db\_instance\_availability\_zone) | The availability zone of the RDS instance |
+| <a name="output_db_instance_endpoint"></a> [db\_instance\_endpoint](#output\_db\_instance\_endpoint) | The connection endpoint |
+| <a name="output_db_skip_final_snapshot"></a> [db\_skip\_final\_snapshot](#output\_db\_skip\_final\_snapshot) | n/a |
+| <a name="output_external_lb_dns_name"></a> [external\_lb\_dns\_name](#output\_external\_lb\_dns\_name) | n/a |
+| <a name="output_install_certmanager"></a> [install\_certmanager](#output\_install\_certmanager) | n/a |
+| <a name="output_install_monitoring"></a> [install\_monitoring](#output\_install\_monitoring) | n/a |
+| <a name="output_install_rancher"></a> [install\_rancher](#output\_install\_rancher) | n/a |
+| <a name="output_k3s_cluster_secret"></a> [k3s\_cluster\_secret](#output\_k3s\_cluster\_secret) | n/a |
+| <a name="output_k3s_tls_san"></a> [k3s\_tls\_san](#output\_k3s\_tls\_san) | n/a |
+| <a name="output_k8s_distribtion"></a> [k8s\_distribtion](#output\_k8s\_distribtion) | n/a |
+| <a name="output_rancher_admin_password"></a> [rancher\_admin\_password](#output\_rancher\_admin\_password) | n/a |
+| <a name="output_rancher_charts_branch"></a> [rancher\_charts\_branch](#output\_rancher\_charts\_branch) | n/a |
+| <a name="output_rancher_charts_repo"></a> [rancher\_charts\_repo](#output\_rancher\_charts\_repo) | n/a |
+| <a name="output_rancher_token"></a> [rancher\_token](#output\_rancher\_token) | n/a |
+| <a name="output_rancher_url"></a> [rancher\_url](#output\_rancher\_url) | n/a |
+| <a name="output_rancher_version"></a> [rancher\_version](#output\_rancher\_version) | n/a |
+| <a name="output_server_k3s_exec"></a> [server\_k3s\_exec](#output\_server\_k3s\_exec) | n/a |
+| <a name="output_tls_cert_file"></a> [tls\_cert\_file](#output\_tls\_cert\_file) | n/a |
+| <a name="output_tls_key_file"></a> [tls\_key\_file](#output\_tls\_key\_file) | n/a |
+| <a name="output_use_new_bootstrap"></a> [use\_new\_bootstrap](#output\_use\_new\_bootstrap) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/control-plane/data.tf
+++ b/control-plane/data.tf
@@ -1,0 +1,19 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnet_ids" "all" {
+  vpc_id = data.aws_vpc.default.id
+}
+
+data "aws_security_group" "default" {
+  vpc_id = data.aws_vpc.default.id
+  name   = "default"
+}
+
+data "aws_route53_zone" "selected" {
+  name         = "${local.domain}."
+  private_zone = false
+}

--- a/control-plane/db.tf
+++ b/control-plane/db.tf
@@ -1,51 +1,55 @@
 resource "aws_security_group" "database" {
+  count  = var.k8s_distribution == "k3s" ? 1 : 0
   name   = "${local.name}-database"
   vpc_id = data.aws_vpc.default.id
 }
 
 resource "aws_security_group_rule" "database_self" {
+  count             = var.k8s_distribution == "k3s" ? 1 : 0
   type              = "ingress"
   from_port         = var.db_port
   to_port           = var.db_port
   protocol          = "TCP"
   self              = true
-  security_group_id = aws_security_group.database.id
+  security_group_id = aws_security_group.database[0].id
 }
 
 
 module "db" {
-  source = "terraform-aws-modules/rds/aws"
+  count   = var.k8s_distribution == "k3s" ? 1 : 0
+  source  = "terraform-aws-modules/rds/aws"
+  version = ">= 3.2"
 
   identifier = local.identifier
 
   # All available versions: http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html#MySQL.Concepts.VersionMgmt
-  engine                = var.db_engine
-  engine_version        = var.db_engine_version
-  major_engine_version  = var.db_engine_version
+  engine               = var.db_engine
+  engine_version       = var.db_engine_version
+  major_engine_version = var.db_engine_version
 
-  instance_class        = var.db_instance_class
-  allocated_storage     = var.db_allocated_storage
-  storage_encrypted     = var.db_storage_encrypted
-  iops                  = var.db_iops
-  storage_type          = var.db_storage_type
-  skip_final_snapshot   = var.db_skip_final_snapshot
+  instance_class      = var.db_instance_class
+  allocated_storage   = var.db_allocated_storage
+  storage_encrypted   = var.db_storage_encrypted
+  iops                = var.db_iops
+  storage_type        = var.db_storage_type
+  skip_final_snapshot = var.db_skip_final_snapshot
 
-  subnet_ids              = data.aws_subnet_ids.all.ids
-  vpc_security_group_ids  = [data.aws_security_group.default.id, aws_security_group.database.id]
-  multi_az                = local.db_multi_az
-  deletion_protection     = false
+  subnet_ids             = data.aws_subnet_ids.all.ids
+  vpc_security_group_ids = [data.aws_security_group.default.id, aws_security_group.database[0].id]
+  multi_az               = local.db_multi_az
+  deletion_protection    = false
 
-  name     = var.db_name
-  username = var.db_username
-  password = var.db_password
-  port     = var.db_port
+  name                         = var.db_name
+  username                     = var.db_username
+  password                     = var.db_password
+  port                         = var.db_port
   create_db_parameter_group    = false
   create_db_subnet_group       = false
   create_db_option_group       = false
   performance_insights_enabled = false
 
-  db_subnet_group_name    = var.db_subnet_group_name != null ? var.db_subnet_group_name : ( var.aws_region == "us-west-1" || var.aws_region == "us-east-1" ) ? "default-${data.aws_vpc.default.id}" : "default"
-  
+  db_subnet_group_name = var.db_subnet_group_name != null ? var.db_subnet_group_name : (var.aws_region == "us-west-1" || var.aws_region == "us-east-1") ? "default-${data.aws_vpc.default.id}" : "default"
+
   maintenance_window      = "Mon:00:00-Mon:03:00"
   backup_window           = "03:00-06:00"
   backup_retention_period = 0

--- a/control-plane/files/values/rancher_chart_values.tftpl
+++ b/control-plane/files/values/rancher_chart_values.tftpl
@@ -1,0 +1,24 @@
+hostname: ${rancher_hostname}
+ingress:
+  tls:
+%{ if !install_certmanager && install_byo_certs ~}
+    source: secret
+    secretName: tls-rancher-ingress
+%{ endif ~}
+%{ if install_certmanager ~}
+    source: letsEncrypt
+letsEncrypt:
+  email: ${letsencrypt_email}
+%{ endif ~}
+%{ if private_ca ~}
+privateCA: ${private_ca}
+%{ endif ~}
+rancherImage: ${rancher_image}
+rancherImageTag: ${rancher_image_tag}
+replicas: ${rancher_node_count}
+%{ if use_new_bootstrap ~}
+bootstrapPassword: ${rancher_password}
+%{ endif ~}
+extraEnv:
+- name: CATTLE_PROMETHEUS_METRICS
+  value: 'true'

--- a/control-plane/files/values/rancher_monitoring_chart_values.yaml
+++ b/control-plane/files/values/rancher_monitoring_chart_values.yaml
@@ -1,0 +1,50 @@
+alertmanager:
+  enabled: false
+grafana:
+  nodeSelector:
+    monitoring: 'yes'
+  tolerations:
+  - key: monitoring
+    operator: Exists
+    effect: NoSchedule
+prometheus:
+  prometheusSpec:
+    evaluationInterval: 1m
+    nodeSelector:
+      monitoring: 'yes'
+    resources:
+      limits:
+        memory: 5000Mi
+    retentionSize: 50GiB
+    scrapeInterval: 1m
+    tolerations:
+    - key: monitoring
+      operator: Exists
+      effect: NoSchedule
+prometheus-adapter:
+  nodeSelector:
+    monitoring: 'yes'
+  tolerations:
+  - key: monitoring
+    operator: Exists
+    effect: NoSchedule
+kube-state-metrics:
+  nodeSelector:
+    monitoring: 'yes'
+  tolerations:
+  - key: monitoring
+    operator: Exists
+    effect: NoSchedule
+prometheusOperator:
+  nodeSelector:
+    monitoring: 'yes'
+  tolerations:
+  - key: monitoring
+    operator: Exists
+    effect: NoSchedule
+global:
+  cattle:
+    clusterId: local
+    clusterName: local
+    systemDefaultRegistry: ''
+  systemDefaultRegistry: ''

--- a/control-plane/files/values/rancher_monitoring_crd_chart_values.yaml
+++ b/control-plane/files/values/rancher_monitoring_crd_chart_values.yaml
@@ -1,0 +1,6 @@
+global:
+  cattle:
+    clusterId: local
+    clusterName: local
+    systemDefaultRegistry: ''
+  systemDefaultRegistry: ''

--- a/control-plane/main.tf
+++ b/control-plane/main.tf
@@ -115,15 +115,15 @@ module "rke1" {
   count  = var.k8s_distribution == "rke1" ? 1 : 0
   source = "./modules/rke1"
 
-  cluster_name           = "local"
-  server_node_count      = var.rancher_node_count
-  ssh_key_path           = var.ssh_key_path
-  install_docker_version = var.install_docker_version
-  install_k8s_version    = var.install_k8s_version
-  s3_instance_profile    = var.s3_instance_profile
-  nodes_ids              = module.aws_infra[0].nodes_ids
-  nodes_public_ips       = module.aws_infra[0].nodes_public_ips
-  nodes_private_ips      = module.aws_infra[0].nodes_private_ips
+  cluster_name             = "local"
+  hostname_override_prefix = local.name
+  ssh_key_path             = var.ssh_key_path
+  install_docker_version   = var.install_docker_version
+  install_k8s_version      = var.install_k8s_version
+  s3_instance_profile      = var.s3_instance_profile
+  nodes_ids                = module.aws_infra[0].nodes_ids
+  nodes_public_ips         = module.aws_infra[0].nodes_public_ips
+  nodes_private_ips        = module.aws_infra[0].nodes_private_ips
 
   depends_on = [
     module.aws_infra
@@ -181,6 +181,12 @@ resource "rancher2_catalog_v2" "rancher_charts_custom" {
   name       = "rancher-charts-custom"
   git_repo   = length(var.rancher_charts_repo) > 0 ? var.rancher_charts_repo : "https://git.rancher.io/charts"
   git_branch = var.rancher_charts_branch
+
+  provisioner "local-exec" {
+    command = <<-EOT
+    sleep 5
+    EOT
+  }
 
   depends_on = [
     module.install_common

--- a/control-plane/main.tf
+++ b/control-plane/main.tf
@@ -4,6 +4,9 @@ terraform {
     rancher2 = {
       source = "rancher/rancher2"
     }
+    rke = {
+      source = "rancher/rke"
+    }
     aws = {
       source = "hashicorp/aws"
     }
@@ -14,43 +17,9 @@ terraform {
       source = "hashicorp/random"
     }
   }
-}
-
-terraform {
   backend "local" {
     path = "rancher.tfstate"
   }
-}
-
-provider "aws" {
-  region  = local.aws_region
-  profile = "rancher-eng"
-}
-
-provider "aws" {
-  region  = local.aws_region
-  profile = "rancher-eng"
-  alias   = "r53"
-}
-
-data "aws_caller_identity" "current" {}
-
-data "aws_vpc" "default" {
-  default = true
-}
-
-data "aws_subnet_ids" "all" {
-  vpc_id = data.aws_vpc.default.id
-}
-
-data "aws_security_group" "default" {
-  vpc_id = data.aws_vpc.default.id
-  name   = "default"
-}
-
-data "aws_route53_zone" "selected" {
-  name         = "${local.domain}."
-  private_zone = false
 }
 
 resource "random_pet" "identifier" {
@@ -62,11 +31,13 @@ resource "random_pet" "identifier" {
 }
 
 locals {
-  aws_region  = var.aws_region
-  name        = random_pet.identifier.id
-  identifier  = random_pet.identifier.id
-  domain      = var.domain
-  db_multi_az = false
+  aws_region         = var.aws_region
+  name               = random_pet.identifier.id
+  identifier         = random_pet.identifier.id
+  domain             = var.domain
+  db_multi_az        = false
+  use_new_bootstrap  = length(regexall("^([2-9]|\\d{3,})\\.([6-9]|\\d{3,})\\.([0-9]|\\d{3,})(-rc\\d{2,})?$", var.rancher_version)) > 0
+  install_monitoring = var.install_monitoring && var.install_rancher
 }
 
 resource "random_password" "rancher_password" {
@@ -76,7 +47,13 @@ resource "random_password" "rancher_password" {
 }
 
 module "k3s" {
-  source                      = "./modules/aws-k3s"
+  count  = var.k8s_distribution == "k3s" ? 1 : 0
+  source = "./modules/aws-k3s"
+  providers = {
+    rancher2 = rancher2.bootstrap,
+    aws      = aws
+  }
+
   vpc_id                      = data.aws_vpc.default.id
   private_subnets_cidr_blocks = ["172.31.48.0/20", "172.31.0.0/20", "172.31.16.0/20", "172.31.32.0/20"]
   name                        = local.name
@@ -85,11 +62,12 @@ module "k3s" {
   db_pass                     = var.db_password
   db_port                     = var.db_port
   db_name                     = var.db_name
-  db_security_group           = aws_security_group.database.id
-  k3s_datastore_endpoint      = module.db.db_instance_endpoint
+  db_security_group           = aws_security_group.database[0].id
+  k3s_datastore_endpoint      = module.db[0].db_instance_endpoint
   k3s_storage_engine          = var.db_engine
   ssh_keys                    = var.ssh_keys
-  install_rancher             = true
+  create_external_nlb         = false
+  install_rancher             = var.install_rancher
   rancher_password            = var.rancher_password != null ? var.rancher_password : random_password.rancher_password.result
   rancher_image               = var.rancher_image
   rancher_image_tag           = var.rancher_image_tag
@@ -98,12 +76,13 @@ module "k3s" {
   install_k3s_version         = var.install_k3s_version
   server_k3s_exec             = var.server_k3s_exec
   rancher_version             = var.rancher_version
+  use_new_bootstrap           = local.use_new_bootstrap
   monitoring_version          = var.monitoring_version
   domain                      = local.domain
   r53_domain                  = var.r53_domain
   letsencrypt_email           = var.letsencrypt_email
   rancher_chart               = var.rancher_chart
-  rancher_chart_tag           = var.rancher_chart_tag
+  rancher_chart_tag           = var.rancher_charts_branch
   install_certmanager         = var.install_certmanager
   certmanager_version         = var.certmanager_version
   byo_certs_bucket_path       = var.byo_certs_bucket_path
@@ -114,21 +93,113 @@ module "k3s" {
   tls_key_file                = var.tls_key_file
 }
 
-provider "rancher2" {
-  alias     = "admin"
-  api_url   = module.k3s.rancher_url
-  token_key = module.k3s.rancher_token
+module "aws_infra" {
+  count  = var.k8s_distribution == "rke1" ? 1 : 0
+  source = "./modules/aws-infra"
+
+  vpc_id                 = data.aws_vpc.default.id
+  create_external_nlb    = true
+  name                   = local.name
+  user                   = data.aws_caller_identity.current.user_id
+  ssh_keys               = var.ssh_keys
+  ssh_key_path           = var.ssh_key_path
+  server_instance_type   = var.rancher_instance_type
+  server_node_count      = var.rancher_node_count
+  install_docker_version = var.install_docker_version
+  domain                 = local.domain
+  r53_domain             = var.r53_domain
+  s3_instance_profile    = var.s3_instance_profile
 }
 
-data "rancher2_cluster" "local" {
-  provider = rancher2.admin
-  name     = "local"
+module "rke1" {
+  count  = var.k8s_distribution == "rke1" ? 1 : 0
+  source = "./modules/rke1"
+
+  cluster_name           = "local"
+  server_node_count      = var.rancher_node_count
+  ssh_key_path           = var.ssh_key_path
+  install_docker_version = var.install_docker_version
+  install_k8s_version    = var.install_k8s_version
+  s3_instance_profile    = var.s3_instance_profile
+  nodes_ids              = module.aws_infra[0].nodes_ids
+  nodes_public_ips       = module.aws_infra[0].nodes_public_ips
+  nodes_private_ips      = module.aws_infra[0].nodes_private_ips
+
   depends_on = [
-    module.k3s
+    module.aws_infra
   ]
 }
 
-resource "local_file" "kubeconfig" {
-  content  = data.rancher2_cluster.local.kube_config
-  filename = "${path.module}/files/.${local.identifier}-tfkubeconfig"
+module "generate_kube_config" {
+  source = "./modules/generate-kube-config"
+
+  kubeconfig_content = var.k8s_distribution == "rke1" ? module.rke1[0].kube_config : module.k3s[0].kube_config
+  kubeconfig_dir     = "${path.module}/files/kube_config"
+  identifier_prefix  = local.name
+}
+
+module "install_common" {
+  count  = var.k8s_distribution == "rke1" ? 1 : 0
+  source = "./modules/install-common"
+
+  providers = {
+    rancher2 = rancher2.bootstrap
+  }
+
+  kube_config_path       = module.generate_kube_config.kubeconfig_path
+  cluster_host_url       = module.rke1[0].api_server_url
+  client_certificate     = module.rke1[0].client_cert
+  client_key             = module.rke1[0].client_key
+  cluster_ca_certificate = module.rke1[0].ca_crt
+
+  subdomain           = local.name
+  domain              = local.domain
+  install_certmanager = var.install_certmanager
+  install_rancher     = var.install_rancher
+
+  helm_rancher_chart_values_path = "${path.module}/files/values/rancher_chart_values.tftpl"
+  letsencrypt_email              = var.letsencrypt_email
+  rancher_image                  = var.rancher_image
+  rancher_image_tag              = var.rancher_image_tag
+  rancher_version                = var.rancher_version
+  rancher_password               = var.rancher_password
+  use_new_bootstrap              = local.use_new_bootstrap
+  rancher_node_count             = var.rancher_node_count
+  byo_certs_bucket_path          = var.byo_certs_bucket_path
+  private_ca_file                = var.private_ca_file
+
+  depends_on = [
+    module.generate_kube_config
+  ]
+}
+
+resource "rancher2_catalog_v2" "rancher_charts_custom" {
+  count    = var.k8s_distribution == "rke1" && local.install_monitoring ? 1 : 0
+  provider = rancher2.admin
+
+  cluster_id = "local"
+  name       = "rancher-charts-custom"
+  git_repo   = length(var.rancher_charts_repo) > 0 ? var.rancher_charts_repo : "https://git.rancher.io/charts"
+  git_branch = var.rancher_charts_branch
+
+  depends_on = [
+    module.install_common
+  ]
+}
+
+resource "rancher2_app_v2" "rancher_monitoring" {
+  count    = var.k8s_distribution == "rke1" && local.install_monitoring ? 1 : 0
+  provider = rancher2.admin
+
+  cluster_id    = "local"
+  name          = "rancher-monitoring"
+  namespace     = "cattle-monitoring-system"
+  repo_name     = "rancher-charts-custom"
+  chart_name    = "rancher-monitoring"
+  chart_version = var.monitoring_version
+  values        = file(var.monitoring_chart_values_path)
+
+  depends_on = [
+    rancher2_catalog_v2.rancher_charts_custom
+  ]
 }

--- a/control-plane/modules/aws-infra/.terraform.lock.hcl
+++ b/control-plane/modules/aws-infra/.terraform.lock.hcl
@@ -2,8 +2,7 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.71.0"
-  constraints = ">= 2.49.0"
+  version = "3.71.0"
   hashes = [
     "h1:5+M8SPZlb3FxcmAX4RykKzNrTHkpjoP1UpHcenOXcxo=",
     "zh:173134d8861a33ed60a48942ad2b96b9d06e85c506d7f927bead47a28f4ebdd2",
@@ -17,60 +16,6 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:b90505897ae4943a74de2b88b6a9e7d97bf6dc325a0222235996580edff28656",
     "zh:ea5e422942ac6fc958229d27d4381c89d21d70c5c2c67a6c06ff357bcded76f6",
     "zh:f1536d7ff2d3bfd668e3ac33d8956b4f988f87fdfdcc371c7d94b98d5dba53e2",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/helm" {
-  version = "2.4.1"
-  hashes = [
-    "h1:CLb4n9f/hLyqqq0zbc+h5SuNOB7KnO65qOOb+ohwsKA=",
-    "zh:07517b24ea2ce4a1d3be3b88c3efc7fb452cd97aea8fac93ca37a08a8ec06e14",
-    "zh:11ef6118ed03a1b40ff66adfe21b8707ece0568dae1347ddfbcff8452c0655d5",
-    "zh:1ae07e9cc6b088a6a68421642c05e2fa7d00ed03e9401e78c258cf22a239f526",
-    "zh:1c5b4cd44033a0d7bf7546df930c55aa41db27b70b3bca6d145faf9b9a2da772",
-    "zh:256413132110ddcb0c3ea17c7b01123ad2d5b70565848a77c5ccc22a3f32b0dd",
-    "zh:4ab46fd9aadddef26604382bc9b49100586647e63ef6384e0c0c3f010ff2f66e",
-    "zh:5a35d23a9f08c36fceda3cef7ce2c7dc5eca32e5f36494de695e09a5007122f0",
-    "zh:8e9823a1e5b985b63fe283b755a821e5011a58112447d42fb969c7258ed57ed3",
-    "zh:8f79722eba9bf77d341edf48a1fd51a52d93ec31d9cac9ba8498a3a061ea4a7f",
-    "zh:b2ea782848b10a343f586ba8ee0cf4d7ff65aa2d4b144eea5bbd8f9801b54c67",
-    "zh:e72d1ccf8a75d8e8456c6bb4d843fd4deb0e962ad8f167fa84cf17f12c12304e",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/kubernetes" {
-  version = "2.7.1"
-  hashes = [
-    "h1:/zifejk3MfLSDQr5J6sc3EHrnFwAVEDH9LrewWMRqe4=",
-    "zh:0da320fd81ece6696f7cceda35e459ee97cae8955088af38fc7f2feab1dce924",
-    "zh:37d304b8b992518c9c12e8f10437b9d4a0cc5a823c9421ac794ad2347c4d1122",
-    "zh:3d4e12fb9588c3b2e782d392fea758c6982e5d653154bec951e949155bcbc169",
-    "zh:6bb32b8d5cccf3e3ae7c124ed27df76dc7653ca760c132addeee15272630c930",
-    "zh:94775153b90e285876fc17261e8f5338a1ff732f4133336cc68754acb74570b6",
-    "zh:a665d1336765cdf8620a8797fd4e7e3cecf789e96e59ba80634336a4390df377",
-    "zh:aa8b35e9958cb89f01c115e8866a07d5468fb53f1c227d673e94f7ee8fb76242",
-    "zh:b7a571336387d773a74ed6eefa3843ff78d3662f2745c99c95008002a1341662",
-    "zh:c50d661782175d50ea4952fe943b0e4a3e33c27aa69e5ff21b3cbfa513e90d0a",
-    "zh:e0999b349cc772c75876adbc2a13b5dc256d3ecd7e4aa91baee5fdfcecaa7465",
-    "zh:e1399aec06a7aa98e9b0f64b4281697247f338a8a40b79f5f6ebfd43bf4ce1e2",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/local" {
-  version = "2.1.0"
-  hashes = [
-    "h1:KfieWtVyGWwplSoLIB5usKAUnrIkDQBkWaR5TI+4WYg=",
-    "zh:0f1ec65101fa35050978d483d6e8916664b7556800348456ff3d09454ac1eae2",
-    "zh:36e42ac19f5d68467aacf07e6adcf83c7486f2e5b5f4339e9671f68525fc87ab",
-    "zh:6db9db2a1819e77b1642ec3b5e95042b202aee8151a0256d289f2e141bf3ceb3",
-    "zh:719dfd97bb9ddce99f7d741260b8ece2682b363735c764cac83303f02386075a",
-    "zh:7598bb86e0378fd97eaa04638c1a4c75f960f62f69d3662e6d80ffa5a89847fe",
-    "zh:ad0a188b52517fec9eca393f1e2c9daea362b33ae2eb38a857b6b09949a727c1",
-    "zh:c46846c8df66a13fee6eff7dc5d528a7f868ae0dcf92d79deaac73cc297ed20c",
-    "zh:dc1a20a2eec12095d04bf6da5321f535351a594a636912361db20eb2a707ccc4",
-    "zh:e57ab4771a9d999401f6badd8b018558357d3cbdf3d33cc0c4f83e818ca8e94b",
-    "zh:ebdcde208072b4b0f8d305ebf2bfdc62c926e0717599dcf8ec2fd8c5845031c3",
-    "zh:ef34c52b68933bedd0868a13ccfd59ff1c820f299760b3c02e008dc95e2ece91",
   ]
 }
 
@@ -93,8 +38,7 @@ provider "registry.terraform.io/hashicorp/null" {
 }
 
 provider "registry.terraform.io/hashicorp/random" {
-  version     = "3.1.0"
-  constraints = ">= 2.2.0, >= 3.1.0"
+  version = "3.1.0"
   hashes = [
     "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
     "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",

--- a/control-plane/modules/aws-infra/README.md
+++ b/control-plane/modules/aws-infra/README.md
@@ -1,0 +1,105 @@
+# aws-infra
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.71.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.1.0 |
+| <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_autoscaling_group.rke1_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
+| [aws_launch_template.rke1_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
+| [aws_lb.lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb.server-public-lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb.server_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb_listener.port_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.port_80](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.server-port_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.server-port_80](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.server_port_6443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_target_group.agent-443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_lb_target_group.agent-80](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_lb_target_group.server-443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_lb_target_group.server-6443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_lb_target_group.server-80](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_route53_record.rancher](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.rke1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_security_group.ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.ingress_egress_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.rke1_server_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.self_dockerd_tls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.self_etcd_comms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.self_ingress_liveness_readiness](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.self_kubelet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.self_nodeport_range](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.self_prom_metrics_linux](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.self_prom_metrics_windows](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.self_rke1_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.self_vxlan](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.self_vxlan_liveness_readiness](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ssh_rke1_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [null_resource.wait_for_bootstrap](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [aws_ami.ubuntu](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_iam_instance_profile.rancher_s3_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_instance_profile) | data source |
+| [aws_instances.nodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/instances) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_route53_zone.dns_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+| [aws_subnet_ids.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+| [template_cloudinit_config.rke1_server](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/cloudinit_config) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aws_azs"></a> [aws\_azs](#input\_aws\_azs) | List of AWS Availability Zones in the VPC | `list(any)` | `null` | no |
+| <a name="input_create_external_nlb"></a> [create\_external\_nlb](#input\_create\_external\_nlb) | Boolean that defines whether or not to create an external load balancer | `bool` | `true` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | n/a | `string` | `""` | no |
+| <a name="input_extra_server_security_groups"></a> [extra\_server\_security\_groups](#input\_extra\_server\_security\_groups) | Additional security groups to attach to rke1 server instances | `list(any)` | `[]` | no |
+| <a name="input_install_docker_version"></a> [install\_docker\_version](#input\_install\_docker\_version) | Version of Docker to install | `string` | `"20.10"` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name for deployment | `string` | `"rancher-demo"` | no |
+| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | List of private subnet ids. | `list(any)` | `[]` | no |
+| <a name="input_private_subnets_cidr_blocks"></a> [private\_subnets\_cidr\_blocks](#input\_private\_subnets\_cidr\_blocks) | List of cidr\_blocks of private subnets | `list(any)` | `[]` | no |
+| <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | List of public subnet ids. | `list(any)` | `[]` | no |
+| <a name="input_r53_domain"></a> [r53\_domain](#input\_r53\_domain) | DNS domain for Route53 zone (defaults to domain if unset) | `string` | `""` | no |
+| <a name="input_s3_instance_profile"></a> [s3\_instance\_profile](#input\_s3\_instance\_profile) | Optional: String that defines the name of the IAM Instance Profile that grants S3 access to the EC2 instances. Required if 'byo\_certs\_bucket\_path' is set | `string` | `""` | no |
+| <a name="input_server_image_id"></a> [server\_image\_id](#input\_server\_image\_id) | AMI to use for rke1 server instances | `string` | `null` | no |
+| <a name="input_server_instance_ssh_user"></a> [server\_instance\_ssh\_user](#input\_server\_instance\_ssh\_user) | Username for sshing into instances | `string` | `"ubuntu"` | no |
+| <a name="input_server_instance_type"></a> [server\_instance\_type](#input\_server\_instance\_type) | n/a | `string` | `"m5.large"` | no |
+| <a name="input_server_node_count"></a> [server\_node\_count](#input\_server\_node\_count) | Number of server nodes to launch | `number` | `1` | no |
+| <a name="input_ssh_key_path"></a> [ssh\_key\_path](#input\_ssh\_key\_path) | Path to the ssh\_key file to be used for connecting to the nodes | `string` | `null` | no |
+| <a name="input_ssh_keys"></a> [ssh\_keys](#input\_ssh\_keys) | SSH keys to inject into Rancher instances | `list(any)` | `[]` | no |
+| <a name="input_subdomain"></a> [subdomain](#input\_subdomain) | subdomain to host rancher on, instead of using `var.name` | `string` | `null` | no |
+| <a name="input_use_route53"></a> [use\_route53](#input\_use\_route53) | Configures whether to use route\_53 DNS or not | `bool` | `true` | no |
+| <a name="input_user"></a> [user](#input\_user) | n/a | `string` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The vpc id that Rancher should use | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_external_lb_dns_name"></a> [external\_lb\_dns\_name](#output\_external\_lb\_dns\_name) | n/a |
+| <a name="output_nodes_ids"></a> [nodes\_ids](#output\_nodes\_ids) | n/a |
+| <a name="output_nodes_private_ips"></a> [nodes\_private\_ips](#output\_nodes\_private\_ips) | n/a |
+| <a name="output_nodes_public_ips"></a> [nodes\_public\_ips](#output\_nodes\_public\_ips) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/control-plane/modules/aws-infra/data.tf
+++ b/control-plane/modules/aws-infra/data.tf
@@ -1,0 +1,87 @@
+data "aws_region" "current" {}
+
+data "aws_vpc" "default" {
+  default = false
+  id      = var.vpc_id
+}
+
+data "aws_subnet_ids" "available" {
+  vpc_id = data.aws_vpc.default.id
+}
+
+data "aws_route53_zone" "dns_zone" {
+  count = local.use_route53
+  name  = local.r53_domain
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"]
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/*/ubuntu-bionic-18.04-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}
+
+data "template_cloudinit_config" "rke1_server" {
+  gzip          = false
+  base64_encode = true
+
+  # Main cloud-config configuration file.
+  part {
+    filename     = "00_cloud-config-base.yaml"
+    content_type = "text/cloud-config"
+    content = templatefile("${path.module}/files/cloud-config-base.tmpl", {
+      ssh_keys               = var.ssh_keys,
+      install_docker_version = var.install_docker_version
+      }
+    )
+  }
+
+  # part {
+  #   filename     = "01_base.sh"
+  #   content_type = "text/x-shellscript"
+  #   content      = file("${path.module}/files/base.sh")
+  #   merge_type   = "list(append)+dict(recurse_array)+str()"
+  # }
+
+  part {
+    filename     = "02_k8s-setup.sh"
+    content_type = "text/x-shellscript"
+    content      = file("${path.module}/files/k8s-setup.sh")
+    merge_type   = "list(append)+dict(recurse_array)+str()"
+  }
+
+  part {
+    filename     = "03_docker-install.sh"
+    content_type = "text/x-shellscript"
+    content      = file("${path.module}/files/docker-install.sh")
+    merge_type   = "list(append)+dict(recurse_array)+str()"
+  }
+}
+
+data "aws_instances" "nodes" {
+  instance_tags = {
+    Name  = local.name
+    Owner = var.user
+  }
+  depends_on = [
+    aws_autoscaling_group.rke1_server
+  ]
+}

--- a/control-plane/modules/aws-infra/data.tf
+++ b/control-plane/modules/aws-infra/data.tf
@@ -78,7 +78,7 @@ data "template_cloudinit_config" "rke1_server" {
 
 data "aws_instances" "nodes" {
   instance_tags = {
-    Name  = local.name
+    Name  = local.instance_names
     Owner = var.user
   }
   depends_on = [

--- a/control-plane/modules/aws-infra/files/base.sh
+++ b/control-plane/modules/aws-infra/files/base.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -xe
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+echo "net.ipv4.ip_local_port_range = 15000 61000" >> /etc/sysctl.conf
+echo "fs.file-max = 12000500" >> /etc/sysctl.conf
+echo "fs.nr_open = 20000500" >> /etc/sysctl.conf
+echo "net.ipv4.tcp_mem = 10000000 10000000 10000000" >> /etc/sysctl.conf
+sysctl -w net.core.rmem_max=8388608
+sysctl -w net.core.wmem_max=8388608
+sysctl -w net.core.rmem_default=65536
+sysctl -w net.core.wmem_default=65536
+sysctl -w net.ipv4.tcp_rmem='4096 87380 8388608'
+sysctl -w net.ipv4.tcp_wmem='4096 65536 8388608'
+sysctl -w net.ipv4.tcp_mem='8388608 8388608 8388608'
+sysctl -w net.ipv4.route.flush=1
+echo "# <domain> <type> <item>  <value>" >> /etc/security/limits.d/limits.conf
+echo "    *       soft  nofile  20000000" >> /etc/security/limits.d/limits.conf
+echo "    *       hard  nofile  20000000" >> /etc/security/limits.d/limits.conf
+sysctl -p
+systemctl disable firewalld --now
+apt-get install -y software-properties-common ntp
+# swapoff -a

--- a/control-plane/modules/aws-infra/files/cloud-config-base.tmpl
+++ b/control-plane/modules/aws-infra/files/cloud-config-base.tmpl
@@ -1,0 +1,9 @@
+#cloud-config
+%{ if length(ssh_keys) > 0 }
+ssh_authorized_keys:
+%{ for ssh_key in ssh_keys }
+- ${ssh_key}
+%{ endfor }
+%{ endif }
+package_upgrade: true
+package_update: true

--- a/control-plane/modules/aws-infra/files/docker-install.sh
+++ b/control-plane/modules/aws-infra/files/docker-install.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -xe
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+apt-get purge -y docker-ce docker-ce-cli containerd.io || true
+apt-get remove -y docker docker-engine docker.io containerd runc || true
+rm -rf /var/lib/docker
+rm -rf /var/lib/containerd
+
+# apt-get update
+# apt-get install -y docker-ce docker-ce-cli containerd.io
+
+curl https://releases.rancher.com/install-docker/20.10.sh | sh && usermod -aG docker ubuntu
+
+until [ "$(pgrep -f --count dockerd)" = "1" ]; do
+  sleep 2
+done
+# if [ -x "$(command -v docker)" ]; then
+#   echo "Docker installed successfully"
+# else
+#   echo "Docker not installed"
+# fi

--- a/control-plane/modules/aws-infra/files/k8s-setup.sh
+++ b/control-plane/modules/aws-infra/files/k8s-setup.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -xe
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+apt-get update
+apt-get install -y apt-transport-https ca-certificates curl
+# curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+# echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
+# apt-get update
+
+# remove kubectl
+# apt-get purge -y kubectl
+
+# enable required kernel modules
+for module in br_netfilter ip6_udp_tunnel ip_set ip_set_hash_ip ip_set_hash_net iptable_filter iptable_nat iptable_mangle iptable_raw nf_conntrack_netlink nf_conntrack nf_defrag_ipv4 nf_nat nfnetlink udp_tunnel veth vxlan x_tables xt_addrtype xt_conntrack xt_comment xt_mark xt_multiport xt_nat xt_recent xt_set xt_statistic xt_tcpudp;
+     do
+       if ! lsmod | grep -q $module; then
+         echo "module $module is not present";
+         modprobe $module
+       fi;
+done
+
+# install kubectl
+# apt-get install -y kubectl
+
+# turn swap off
+echo "swapoff -a" >> /etc/fstab
+
+# set recommended networking options
+sysctl -w net.bridge.bridge-nf-call-iptables=1
+sysctl -w net.ipv4.ip_forward=1
+sysctl -w net.bridge.bridge-nf-call-ip6tables=1
+sysctl --system
+
+echo "AllowTcpForwarding yes" >> /etc/ssh/sshd_config
+systemctl restart ssh
+
+until [ "$(pgrep -f --count ssh)" = "3" ]; do
+  sleep 2
+done

--- a/control-plane/modules/aws-infra/infra.tf
+++ b/control-plane/modules/aws-infra/infra.tf
@@ -1,0 +1,258 @@
+#############################
+### Access Control
+#############################
+
+resource "aws_security_group" "ingress" {
+  name   = "${local.name}-ingress"
+  vpc_id = data.aws_vpc.default.id
+}
+
+resource "aws_security_group_rule" "ingress_http" {
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "TCP"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.ingress.id
+}
+
+resource "aws_security_group_rule" "ingress_https" {
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "TCP"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.ingress.id
+}
+
+resource "aws_security_group_rule" "ingress_self" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  self              = true
+  security_group_id = aws_security_group.ingress.id
+}
+
+resource "aws_security_group_rule" "ingress_egress_all" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.ingress.id
+}
+
+resource "aws_security_group" "self" {
+  name   = "${local.name}-self"
+  vpc_id = data.aws_vpc.default.id
+}
+
+# resource "aws_security_group_rule" "self_self" {
+#   type              = "ingress"
+#   from_port         = 0
+#   to_port           = 0
+#   protocol          = "-1"
+#   self              = true
+#   security_group_id = aws_security_group.self.id
+# }
+
+resource "aws_security_group_rule" "self_rke1_server" {
+  type              = "ingress"
+  from_port         = 6443
+  to_port           = 6443
+  protocol          = "TCP"
+  cidr_blocks       = local.private_subnets_cidr_blocks
+  security_group_id = aws_security_group.self.id
+}
+
+resource "aws_security_group_rule" "self_dockerd_tls" {
+  type              = "ingress"
+  from_port         = 2376
+  to_port           = 2376
+  protocol          = "TCP"
+  cidr_blocks       = local.private_subnets_cidr_blocks
+  security_group_id = aws_security_group.self.id
+}
+
+resource "aws_security_group_rule" "self_etcd_comms" {
+  type              = "ingress"
+  from_port         = 2379
+  to_port           = 2380
+  protocol          = "TCP"
+  self              = true
+  security_group_id = aws_security_group.self.id
+}
+
+resource "aws_security_group_rule" "self_vxlan" {
+  type              = "ingress"
+  from_port         = 8472
+  to_port           = 8472
+  protocol          = "UDP"
+  self              = true
+  security_group_id = aws_security_group.self.id
+}
+
+resource "aws_security_group_rule" "self_vxlan_liveness_readiness" {
+  type              = "ingress"
+  from_port         = 9099
+  to_port           = 9099
+  protocol          = "TCP"
+  self              = true
+  security_group_id = aws_security_group.self.id
+}
+
+resource "aws_security_group_rule" "self_prom_metrics_linux" {
+  type              = "ingress"
+  from_port         = 9100
+  to_port           = 9100
+  protocol          = "TCP"
+  self              = true
+  security_group_id = aws_security_group.self.id
+}
+
+resource "aws_security_group_rule" "self_prom_metrics_windows" {
+  type              = "ingress"
+  from_port         = 9796
+  to_port           = 9796
+  protocol          = "TCP"
+  self              = true
+  security_group_id = aws_security_group.self.id
+}
+
+resource "aws_security_group_rule" "self_kubelet" {
+  type              = "ingress"
+  from_port         = 10250
+  to_port           = 10250
+  protocol          = "TCP"
+  self              = true
+  security_group_id = aws_security_group.self.id
+}
+
+resource "aws_security_group_rule" "self_ingress_liveness_readiness" {
+  type              = "ingress"
+  from_port         = 10254
+  to_port           = 10254
+  protocol          = "TCP"
+  self              = true
+  security_group_id = aws_security_group.self.id
+}
+
+resource "aws_security_group_rule" "self_nodeport_range" {
+  type              = "ingress"
+  from_port         = 30000
+  to_port           = 32767
+  protocol          = "TCP"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.self.id
+}
+
+resource "aws_security_group_rule" "rke1_server_egress" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.self.id
+}
+
+resource "aws_security_group_rule" "ssh_rke1_server" {
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "TCP"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.self.id
+}
+
+#############################
+### Create Nodes
+#############################
+
+data "aws_iam_instance_profile" "rancher_s3_access" {
+  count = length(local.s3_instance_profile) > 0 ? 1 : 0
+  name  = local.s3_instance_profile
+}
+
+resource "aws_launch_template" "rke1_server" {
+  name_prefix   = local.name
+  image_id      = local.server_image_id
+  instance_type = local.server_instance_type
+  user_data     = data.template_cloudinit_config.rke1_server.rendered
+
+  iam_instance_profile {
+    arn = length(local.s3_instance_profile) > 0 ? data.aws_iam_instance_profile.rancher_s3_access[0].arn : null
+  }
+
+  block_device_mappings {
+    device_name = "/dev/sda1"
+
+    ebs {
+      encrypted   = true
+      volume_type = "gp2"
+      volume_size = "50"
+    }
+  }
+
+  network_interfaces {
+    delete_on_termination = true
+    security_groups       = concat([aws_security_group.ingress.id, aws_security_group.self.id], var.extra_server_security_groups)
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "rke1_server" {
+  name_prefix         = local.name
+  desired_capacity    = local.server_node_count + 1
+  max_size            = local.server_node_count + 1
+  min_size            = local.server_node_count + 1
+  vpc_zone_identifier = local.private_subnets
+
+  target_group_arns = [
+    aws_lb_target_group.server-6443.arn,
+    aws_lb_target_group.server-80.arn,
+    aws_lb_target_group.server-443.arn
+  ]
+
+  launch_template {
+    id      = aws_launch_template.rke1_server.id
+    version = aws_launch_template.rke1_server.latest_version
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  dynamic "tag" {
+    for_each = local.asg_tags
+    content {
+      key                 = tag.value.key
+      value               = tag.value.value
+      propagate_at_launch = true
+    }
+  }
+}
+
+#############################
+### Create Public Rancher DNS
+#############################
+resource "aws_route53_record" "rancher" {
+  count   = local.use_route53
+  zone_id = data.aws_route53_zone.dns_zone.0.zone_id
+  name    = "${local.subdomain}.${local.domain}"
+  type    = "CNAME"
+  ttl     = 30
+  records = [aws_lb.server-public-lb.dns_name]
+}
+
+resource "aws_route53_record" "rke1" {
+  count   = local.use_route53
+  zone_id = data.aws_route53_zone.dns_zone.0.zone_id
+  name    = "${local.subdomain}-rke1.${local.domain}"
+  type    = "CNAME"
+  ttl     = 30
+  records = [aws_lb.server_lb.dns_name]
+}

--- a/control-plane/modules/aws-infra/loadbalancer.tf
+++ b/control-plane/modules/aws-infra/loadbalancer.tf
@@ -1,0 +1,203 @@
+resource "aws_lb" "server_lb" {
+  name               = "${local.name}-int"
+  internal           = true
+  load_balancer_type = "network"
+  subnets            = local.private_subnets
+
+  tags = {
+    for tag in local.custom_tags : "${tag.key}" => "${tag.value}"
+  }
+
+}
+
+resource "aws_lb_listener" "server_port_6443" {
+  load_balancer_arn = aws_lb.server_lb.arn
+  port              = "6443"
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.server-6443.arn
+  }
+}
+
+resource "aws_lb_target_group" "server-6443" {
+  name     = "${local.name}-server-6443"
+  port     = 6443
+  protocol = "TCP"
+  vpc_id   = data.aws_vpc.default.id
+}
+
+resource "aws_lb" "lb" {
+  count              = local.create_external_nlb
+  name               = "${local.name}-ext"
+  internal           = false
+  load_balancer_type = "network"
+  subnets            = local.public_subnets
+
+  tags = {
+    for tag in local.custom_tags : "${tag.key}" => "${tag.value}"
+  }
+}
+
+resource "aws_lb_listener" "port_443" {
+  count             = local.create_external_nlb
+  load_balancer_arn = aws_lb.lb.0.arn
+  port              = "443"
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.agent-443[0].arn
+  }
+}
+
+resource "aws_lb_listener" "port_80" {
+  count             = local.create_external_nlb
+  load_balancer_arn = aws_lb.lb.0.arn
+  port              = "80"
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.agent-80[0].arn
+  }
+}
+
+resource "aws_lb_target_group" "agent-443" {
+  count    = local.create_external_nlb
+  name     = "${local.name}-agent-443"
+  port     = 443
+  protocol = "TCP"
+  vpc_id   = data.aws_vpc.default.id
+
+  health_check {
+    interval            = 10
+    timeout             = 6
+    path                = ""
+    port                = 80
+    protocol            = "HTTP"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    matcher             = ""
+  }
+
+  stickiness {
+    type    = "source_ip"
+    enabled = false
+  }
+
+  tags = {
+    for tag in local.custom_tags : "${tag.key}" => "${tag.value}"
+  }
+}
+
+resource "aws_lb_target_group" "agent-80" {
+  count    = local.create_external_nlb
+  name     = "${local.name}-agent-80"
+  port     = 80
+  protocol = "TCP"
+  vpc_id   = data.aws_vpc.default.id
+
+  health_check {
+    interval            = 10
+    timeout             = 6
+    path                = "/healthz"
+    port                = 80
+    protocol            = "HTTP"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    matcher             = "200-399"
+  }
+
+  tags = {
+    for tag in local.custom_tags : "${tag.key}" => "${tag.value}"
+  }
+}
+
+resource "aws_lb" "server-public-lb" {
+  name               = local.name
+  internal           = false
+  load_balancer_type = "network"
+  subnets            = local.public_subnets
+
+  tags = {
+    for tag in local.custom_tags : "${tag.key}" => "${tag.value}"
+  }
+}
+
+resource "aws_lb_target_group" "server-443" {
+  name     = "${local.name}-443"
+  port     = 443
+  protocol = "TCP"
+  vpc_id   = data.aws_vpc.default.id
+
+  health_check {
+    interval            = 10
+    timeout             = 6
+    path                = "/healthz"
+    port                = 80
+    protocol            = "HTTP"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    matcher             = ""
+  }
+
+  stickiness {
+    type    = "source_ip"
+    enabled = false
+  }
+
+  tags = {
+    for tag in local.custom_tags : "${tag.key}" => "${tag.value}"
+  }
+}
+
+resource "aws_lb_target_group" "server-80" {
+  name     = "${local.name}-80"
+  port     = 80
+  protocol = "TCP"
+  vpc_id   = data.aws_vpc.default.id
+
+  health_check {
+    interval            = 10
+    timeout             = 6
+    path                = "/healthz"
+    port                = 80
+    protocol            = "HTTP"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    matcher             = "200-399"
+  }
+
+  stickiness {
+    type    = "source_ip"
+    enabled = false
+  }
+
+  tags = {
+    for tag in local.custom_tags : "${tag.key}" => "${tag.value}"
+  }
+}
+
+resource "aws_lb_listener" "server-port_443" {
+  load_balancer_arn = aws_lb.server-public-lb.arn
+  port              = "443"
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.server-443.arn
+  }
+}
+
+resource "aws_lb_listener" "server-port_80" {
+  load_balancer_arn = aws_lb.server-public-lb.arn
+  port              = "80"
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.server-80.arn
+  }
+}

--- a/control-plane/modules/aws-infra/main.tf
+++ b/control-plane/modules/aws-infra/main.tf
@@ -1,0 +1,93 @@
+terraform {
+  required_providers {
+    rancher2 = {
+      source = "rancher/rancher2"
+    }
+    rke = {
+      source = "rancher/rke"
+    }
+    aws = {
+      source = "hashicorp/aws"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+}
+
+locals {
+  name                        = var.name
+  server_instance_type        = var.server_instance_type
+  server_image_id             = var.server_image_id != null ? var.server_image_id : data.aws_ami.ubuntu.id
+  aws_azs                     = var.aws_azs
+  public_subnets              = length(var.public_subnets) > 0 ? var.public_subnets : data.aws_subnet_ids.available.ids
+  private_subnets             = length(var.private_subnets) > 0 ? var.private_subnets : data.aws_subnet_ids.available.ids
+  server_node_count           = var.server_node_count
+  ssh_keys                    = var.ssh_keys
+  install_docker_version      = var.install_docker_version
+  s3_instance_profile         = var.s3_instance_profile
+  domain                      = var.domain
+  r53_domain                  = length(var.r53_domain) > 0 ? var.r53_domain : local.domain
+  private_subnets_cidr_blocks = length(var.private_subnets_cidr_blocks) > 0 ? var.private_subnets_cidr_blocks : ["0.0.0.0/0"]
+  create_external_nlb         = var.create_external_nlb ? 1 : 0
+  use_route53                 = var.use_route53 ? 1 : 0
+  subdomain                   = var.subdomain != null ? var.subdomain : var.name
+  # k8s_cluster_tag             = "kubernetes.io/cluster/${var.name}"
+  k8s_cluster_tag = "kubernetes.io/cluster/${local.subdomain}"
+  # k8s_cluster_tag = "kubernetes.io/cluster/rke1-local"
+  custom_tags = [
+    {
+      key   = local.k8s_cluster_tag
+      value = "owned"
+    },
+    {
+      key   = "rancher.user"
+      value = var.user
+    }
+  ]
+  asg_tags = concat(
+    [
+      {
+        "key"   = "Name"
+        "value" = local.name
+      },
+      {
+        "key"   = "Owner"
+        "value" = var.user
+      },
+      {
+        "key"   = "DoNotDelete"
+        "value" = "true"
+      }
+    ], local.custom_tags
+  )
+}
+
+resource "null_resource" "wait_for_bootstrap" {
+  count = var.server_node_count + 1
+
+  connection {
+    type = "ssh"
+    host = coalesce(data.aws_instances.nodes.public_ips[count.index], data.aws_instances.nodes.private_ips[count.index])
+    user = var.server_instance_ssh_user
+    port = 22
+    # agent = true
+    private_key = file(var.ssh_key_path)
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "cloud-init status --wait"
+    ]
+  }
+
+  depends_on = [
+    aws_autoscaling_group.rke1_server
+  ]
+}

--- a/control-plane/modules/aws-infra/main.tf
+++ b/control-plane/modules/aws-infra/main.tf
@@ -23,6 +23,7 @@ terraform {
 
 locals {
   name                        = var.name
+  instance_names              = "${local.name}-RKE1-HA"
   server_instance_type        = var.server_instance_type
   server_image_id             = var.server_image_id != null ? var.server_image_id : data.aws_ami.ubuntu.id
   aws_azs                     = var.aws_azs
@@ -38,9 +39,7 @@ locals {
   create_external_nlb         = var.create_external_nlb ? 1 : 0
   use_route53                 = var.use_route53 ? 1 : 0
   subdomain                   = var.subdomain != null ? var.subdomain : var.name
-  # k8s_cluster_tag             = "kubernetes.io/cluster/${var.name}"
-  k8s_cluster_tag = "kubernetes.io/cluster/${local.subdomain}"
-  # k8s_cluster_tag = "kubernetes.io/cluster/rke1-local"
+  k8s_cluster_tag             = "kubernetes.io/cluster/${local.subdomain}"
   custom_tags = [
     {
       key   = local.k8s_cluster_tag
@@ -55,7 +54,7 @@ locals {
     [
       {
         "key"   = "Name"
-        "value" = local.name
+        "value" = local.instance_names
       },
       {
         "key"   = "Owner"

--- a/control-plane/modules/aws-infra/output.tf
+++ b/control-plane/modules/aws-infra/output.tf
@@ -1,0 +1,15 @@
+output "external_lb_dns_name" {
+  value = local.create_external_nlb > 0 ? aws_lb.lb.0.dns_name : null
+}
+
+output "nodes_ids" {
+  value = data.aws_instances.nodes.ids
+}
+
+output "nodes_private_ips" {
+  value = data.aws_instances.nodes.private_ips
+}
+
+output "nodes_public_ips" {
+  value = data.aws_instances.nodes.public_ips
+}

--- a/control-plane/modules/aws-infra/variables.tf
+++ b/control-plane/modules/aws-infra/variables.tf
@@ -18,8 +18,8 @@ variable "ssh_key_path" {
 
 variable "name" {
   type        = string
-  default     = "rancher-demo"
-  description = "Name for deployment"
+  default     = "rancher-scaling"
+  description = "Name used for various resources, used as a prefix for individual instance names"
 }
 
 variable "subdomain" {

--- a/control-plane/modules/aws-infra/variables.tf
+++ b/control-plane/modules/aws-infra/variables.tf
@@ -1,0 +1,121 @@
+variable "server_image_id" {
+  type        = string
+  default     = null
+  description = "AMI to use for rke1 server instances"
+}
+
+variable "ssh_keys" {
+  type        = list(any)
+  default     = []
+  description = "SSH keys to inject into Rancher instances"
+}
+
+variable "ssh_key_path" {
+  default     = null
+  type        = string
+  description = "Path to the ssh_key file to be used for connecting to the nodes"
+}
+
+variable "name" {
+  type        = string
+  default     = "rancher-demo"
+  description = "Name for deployment"
+}
+
+variable "subdomain" {
+  default     = null
+  type        = string
+  description = "subdomain to host rancher on, instead of using `var.name`"
+}
+
+variable "domain" {
+  type    = string
+  default = ""
+}
+
+variable "r53_domain" {
+  type        = string
+  default     = ""
+  description = "DNS domain for Route53 zone (defaults to domain if unset)"
+}
+
+variable "server_instance_type" {
+  type    = string
+  default = "m5.large"
+}
+
+variable "server_node_count" {
+  type        = number
+  default     = 1
+  description = "Number of server nodes to launch"
+}
+
+variable "server_instance_ssh_user" {
+  type        = string
+  default     = "ubuntu"
+  description = "Username for sshing into instances"
+}
+
+variable "install_docker_version" {
+  type        = string
+  default     = "20.10"
+  description = "Version of Docker to install"
+}
+
+variable "vpc_id" {
+  type        = string
+  default     = null
+  description = "The vpc id that Rancher should use"
+}
+
+variable "public_subnets" {
+  default     = []
+  type        = list(any)
+  description = "List of public subnet ids."
+}
+
+variable "private_subnets" {
+  default     = []
+  type        = list(any)
+  description = "List of private subnet ids."
+}
+
+variable "extra_server_security_groups" {
+  default     = []
+  type        = list(any)
+  description = "Additional security groups to attach to rke1 server instances"
+}
+
+variable "aws_azs" {
+  default     = null
+  type        = list(any)
+  description = "List of AWS Availability Zones in the VPC"
+}
+
+variable "private_subnets_cidr_blocks" {
+  default     = []
+  type        = list(any)
+  description = "List of cidr_blocks of private subnets"
+}
+
+variable "s3_instance_profile" {
+  default     = ""
+  type        = string
+  description = "Optional: String that defines the name of the IAM Instance Profile that grants S3 access to the EC2 instances. Required if 'byo_certs_bucket_path' is set"
+}
+
+variable "create_external_nlb" {
+  default     = true
+  type        = bool
+  description = "Boolean that defines whether or not to create an external load balancer"
+}
+
+variable "use_route53" {
+  default     = true
+  type        = bool
+  description = "Configures whether to use route_53 DNS or not"
+}
+
+variable "user" {
+  type = string
+}

--- a/control-plane/modules/aws-infra/versions.tf
+++ b/control-plane/modules/aws-infra/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 1.0"
+}

--- a/control-plane/modules/aws-k3s/README.md
+++ b/control-plane/modules/aws-k3s/README.md
@@ -3,68 +3,155 @@
 This module supports creating a k3s cluster with a postgres backend in AWS. It allows you to optionally install nginx-ingress, Rancher Server, and cert-manager, or import your K3S cluster into an existing Rancher Server.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.69.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.1.0 |
+| <a name="provider_rancher2"></a> [rancher2](#provider\_rancher2) | 1.21.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
+| <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_autoscaling_group.k3s_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
+| [aws_autoscaling_group.k3s_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
+| [aws_launch_template.k3s_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
+| [aws_launch_template.k3s_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
+| [aws_lb.lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb.server-public-lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb.server_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb_listener.port_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.port_80](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.server-port_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.server-port_80](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.server_port_6443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_target_group.agent-443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_lb_target_group.agent-80](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_lb_target_group.server-443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_lb_target_group.server-6443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_lb_target_group.server-80](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_route53_record.k3s](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.rancher](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_security_group.ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.ingress_egress_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.k3s_server_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.self_k3s_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.self_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ssh_k3s_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [null_resource.wait_for_rancher](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [rancher2_bootstrap.admin](https://registry.terraform.io/providers/rancher/rancher2/latest/docs/resources/bootstrap) | resource |
+| [random_password.k3s_cluster_secret](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [aws_ami.ubuntu](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_iam_instance_profile.rancher_s3_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_instance_profile) | data source |
+| [aws_route53_zone.dns_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+| [aws_subnet_ids.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+| [rancher2_cluster.local](https://registry.terraform.io/providers/rancher/rancher2/latest/docs/data-sources/cluster) | data source |
+| [template_cloudinit_config.k3s_agent](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/cloudinit_config) | data source |
+| [template_cloudinit_config.k3s_server](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/cloudinit_config) | data source |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| agent\_image\_id | AMI to use for k3s agent instances | string | `"null"` | no |
-| agent\_instance\_ssh\_user | Username for sshing into instances | string | `"ubuntu"` | no |
-| agent\_instance\_type |  | string | `"m5.large"` | no |
-| agent\_k3s\_exec | exec args to pass to k3s agents | string | `"null"` | no |
-| agent\_node\_count | Number of agent nodes to launch | number | `"3"` | no |
-| aws\_azs | List of AWS Availability Zones in the VPC | list | `"null"` | no |
-| aws\_profile | Name of the AWS Profile to use for authentication | string | `"null"` | no |
-| aws\_region |  | string | `"null"` | no |
-| certmanager\_version | Version of cert-manager to install | string | `"0.9.1"` | no |
-| create\_external\_nlb | Boolean that defines whether or not to create an external load balancer | bool | `"true"` | no |
-| db\_instance\_type |  | string | `"db.r5.large"` | no |
-| db\_name | Name of database to create in RDS | string | `"null"` | no |
-| db\_node\_count | Number of RDS database instances to launch | number | `"1"` | no |
-| db\_pass | Password for RDS user | string | n/a | yes |
-| db\_user | Username for RDS database | string | n/a | yes |
-| domain |  | string | `"eng.rancher.space"` | no |
-| extra\_agent\_security\_groups | Additional security groups to attach to k3s agent instances | list | `[]` | no |
-| extra\_server\_security\_groups | Additional security groups to attach to k3s server instances | list | `[]` | no |
-| install\_certmanager | Boolean that defines whether or not to install Cert-Manager | bool | `"false"` | no |
-| install\_k3s\_version | Version of K3S to install | string | `"0.9.1"` | no |
-| install\_nginx\_ingress | Boolean that defines whether or not to install nginx-ingress | bool | `"false"` | no |
-| install\_rancher | Boolean that defines whether or not to install Rancher | bool | `"false"` | no |
-| k3s\_cluster\_secret | Override to set k3s cluster registration secret | string | `"null"` | no |
-| k3s\_deploy\_traefik | Configures whether to deploy traefik ingress or not | bool | `"true"` | no |
-| k3s\_disable\_agent | Whether to run the k3s agent on the same host as the k3s server | bool | `"false"` | no |
-| k3s\_storage\_cafile | Location to download RDS CA Bundle | string | `"/srv/rds-combined-ca-bundle.pem"` | no |
-| k3s\_storage\_endpoint | Storage Backend for K3S cluster to use. Valid options are 'sqlite' or 'postgres' | string | `"sqlite"` | no |
-| k3s\_tls\_san | Sets k3s tls-san flag to this value instead of the default load balancer | string | `"null"` | no |
-| letsencrypt\_email | LetsEncrypt email address to use | string | `"none@none.com"` | no |
-| name | Name for deployment | string | `"rancher-demo"` | no |
-| private\_subnets | List of private subnet ids. | list | `[]` | no |
-| private\_subnets\_cidr\_blocks | List of cidr_blocks of private subnets | list | `[]` | no |
-| public\_subnets | List of public subnet ids. | list | `[]` | no |
-| public\_subnets\_cidr\_blocks | List of cidr_blocks of public subnets | list | `[]` | no |
-| r53\_domain | DNS domain for Route53 zone (defaults to domain if unset) | string | `""` | no |
-| rancher2\_token\_key | Rancher2 API token for authentication | string | `"null"` | no |
-| rancher\_chart | Helm chart to use for Rancher install | string | `"rancher-stable/rancher"` | no |
-| rancher\_password | Password to set for admin user during bootstrap of Rancher Server | string | `""` | no |
-| rancher\_version | Version of Rancher to install | string | `"2.3.1"` | no |
-| registration\_command | Registration command to import cluster into Rancher. Should not be used when installing Rancher in this same cluster | string | `""` | no |
-| server\_image\_id | AMI to use for k3s server instances | string | `"null"` | no |
-| server\_instance\_ssh\_user | Username for sshing into instances | string | `"ubuntu"` | no |
-| server\_instance\_type |  | string | `"m5.large"` | no |
-| server\_k3s\_exec | exec args to pass to k3s server | string | `"null"` | no |
-| server\_node\_count | Number of server nodes to launch | number | `"1"` | no |
-| skip\_final\_snapshot | Boolean that defines whether or not the final snapshot should be created on RDS cluster deletion | bool | `"true"` | no |
-| ssh\_keys | SSH keys to inject into Rancher instances | list | `[]` | no |
-| use\_route53 | Configures whether to use route_53 DNS or not | bool | `"true"` | no |
-| vpc\_id | The vpc id that Rancher should use | string | `"null"` | no |
+|------|-------------|------|---------|:--------:|
+| <a name="input_agent_image_id"></a> [agent\_image\_id](#input\_agent\_image\_id) | AMI to use for k3s agent instances | `string` | `null` | no |
+| <a name="input_agent_instance_ssh_user"></a> [agent\_instance\_ssh\_user](#input\_agent\_instance\_ssh\_user) | Username for sshing into instances | `string` | `"ubuntu"` | no |
+| <a name="input_agent_instance_type"></a> [agent\_instance\_type](#input\_agent\_instance\_type) | n/a | `string` | `"m5.large"` | no |
+| <a name="input_agent_k3s_exec"></a> [agent\_k3s\_exec](#input\_agent\_k3s\_exec) | exec args to pass to k3s agents | `string` | `null` | no |
+| <a name="input_agent_node_count"></a> [agent\_node\_count](#input\_agent\_node\_count) | Number of agent nodes to launch | `number` | `0` | no |
+| <a name="input_aws_azs"></a> [aws\_azs](#input\_aws\_azs) | List of AWS Availability Zones in the VPC | `list(any)` | `null` | no |
+| <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | Name of the AWS Profile to use for authentication | `string` | `null` | no |
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | n/a | `string` | `null` | no |
+| <a name="input_byo_certs_bucket_path"></a> [byo\_certs\_bucket\_path](#input\_byo\_certs\_bucket\_path) | Optional: String that defines the path on the S3 Bucket where your certs are stored. NOTE: assumes certs are stored in a tarball within a folder below the top-level bucket e.g.: my-bucket/certificates/my\_certs.tar.gz. Certs should be stored within a single folder, certs nested in sub-folders will not be handled | `string` | `""` | no |
+| <a name="input_certmanager_version"></a> [certmanager\_version](#input\_certmanager\_version) | Version of cert-manager to install | `string` | `"1.5.2"` | no |
+| <a name="input_create_external_nlb"></a> [create\_external\_nlb](#input\_create\_external\_nlb) | Boolean that defines whether or not to create an external load balancer | `bool` | `true` | no |
+| <a name="input_db_instance_type"></a> [db\_instance\_type](#input\_db\_instance\_type) | n/a | `string` | `"db.r5.xlarge"` | no |
+| <a name="input_db_name"></a> [db\_name](#input\_db\_name) | Name of database to create in RDS | `string` | `"rancher"` | no |
+| <a name="input_db_node_count"></a> [db\_node\_count](#input\_db\_node\_count) | Number of RDS database instances to launch | `number` | `1` | no |
+| <a name="input_db_pass"></a> [db\_pass](#input\_db\_pass) | Password for RDS user | `string` | n/a | yes |
+| <a name="input_db_port"></a> [db\_port](#input\_db\_port) | n/a | `number` | n/a | yes |
+| <a name="input_db_security_group"></a> [db\_security\_group](#input\_db\_security\_group) | n/a | `string` | n/a | yes |
+| <a name="input_db_user"></a> [db\_user](#input\_db\_user) | Username for RDS database | `string` | n/a | yes |
+| <a name="input_domain"></a> [domain](#input\_domain) | n/a | `string` | `""` | no |
+| <a name="input_extra_agent_security_groups"></a> [extra\_agent\_security\_groups](#input\_extra\_agent\_security\_groups) | Additional security groups to attach to k3s agent instances | `list(any)` | `[]` | no |
+| <a name="input_extra_server_security_groups"></a> [extra\_server\_security\_groups](#input\_extra\_server\_security\_groups) | Additional security groups to attach to k3s server instances | `list(any)` | `[]` | no |
+| <a name="input_install_certmanager"></a> [install\_certmanager](#input\_install\_certmanager) | Boolean that defines whether or not to install Cert-Manager | `bool` | `true` | no |
+| <a name="input_install_k3s_version"></a> [install\_k3s\_version](#input\_install\_k3s\_version) | Version of K3S to install | `string` | `"1.0.0"` | no |
+| <a name="input_install_nginx_ingress"></a> [install\_nginx\_ingress](#input\_install\_nginx\_ingress) | Boolean that defines whether or not to install nginx-ingress | `bool` | `true` | no |
+| <a name="input_install_rancher"></a> [install\_rancher](#input\_install\_rancher) | Boolean that defines whether or not to install Rancher | `bool` | `false` | no |
+| <a name="input_k3s_cluster_secret"></a> [k3s\_cluster\_secret](#input\_k3s\_cluster\_secret) | Override to set k3s cluster registration secret | `string` | `null` | no |
+| <a name="input_k3s_datastore_cafile"></a> [k3s\_datastore\_cafile](#input\_k3s\_datastore\_cafile) | Location to download RDS CA Bundle | `string` | `"/srv/rds-combined-ca-bundle.pem"` | no |
+| <a name="input_k3s_datastore_endpoint"></a> [k3s\_datastore\_endpoint](#input\_k3s\_datastore\_endpoint) | Storage Backend for K3S cluster to use. Valid options are 'sqlite' or 'postgres' | `string` | n/a | yes |
+| <a name="input_k3s_deploy_traefik"></a> [k3s\_deploy\_traefik](#input\_k3s\_deploy\_traefik) | Configures whether to deploy traefik ingress or not | `bool` | `false` | no |
+| <a name="input_k3s_disable_agent"></a> [k3s\_disable\_agent](#input\_k3s\_disable\_agent) | Whether to run the k3s agent on the same host as the k3s server | `bool` | `false` | no |
+| <a name="input_k3s_storage_engine"></a> [k3s\_storage\_engine](#input\_k3s\_storage\_engine) | n/a | `string` | n/a | yes |
+| <a name="input_k3s_tls_san"></a> [k3s\_tls\_san](#input\_k3s\_tls\_san) | Sets k3s tls-san flag to this value instead of the default load balancer | `string` | `null` | no |
+| <a name="input_letsencrypt_email"></a> [letsencrypt\_email](#input\_letsencrypt\_email) | LetsEncrypt email address to use | `string` | `"none@none.com"` | no |
+| <a name="input_monitoring_version"></a> [monitoring\_version](#input\_monitoring\_version) | Version of Monitoring v2 to install - Do not include the v prefix. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name for deployment | `string` | `"rancher-demo"` | no |
+| <a name="input_private_ca_file"></a> [private\_ca\_file](#input\_private\_ca\_file) | Optional: String that defines the name of the private CA .pem file in the specified S3 bucket's cert tarball | `string` | `""` | no |
+| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | List of private subnet ids. | `list(any)` | `[]` | no |
+| <a name="input_private_subnets_cidr_blocks"></a> [private\_subnets\_cidr\_blocks](#input\_private\_subnets\_cidr\_blocks) | List of cidr\_blocks of private subnets | `list(any)` | `[]` | no |
+| <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | List of public subnet ids. | `list(any)` | `[]` | no |
+| <a name="input_public_subnets_cidr_blocks"></a> [public\_subnets\_cidr\_blocks](#input\_public\_subnets\_cidr\_blocks) | List of cidr\_blocks of public subnets | `list(any)` | `[]` | no |
+| <a name="input_r53_domain"></a> [r53\_domain](#input\_r53\_domain) | DNS domain for Route53 zone (defaults to domain if unset) | `string` | `""` | no |
+| <a name="input_rancher_chart"></a> [rancher\_chart](#input\_rancher\_chart) | Helm chart to use for Rancher install | `string` | `"rancher-stable/rancher"` | no |
+| <a name="input_rancher_chart_tag"></a> [rancher\_chart\_tag](#input\_rancher\_chart\_tag) | The github tag for the desired Rancher chart version | `string` | `"release-v2.5"` | no |
+| <a name="input_rancher_image"></a> [rancher\_image](#input\_rancher\_image) | n/a | `string` | `"rancher/rancher"` | no |
+| <a name="input_rancher_image_tag"></a> [rancher\_image\_tag](#input\_rancher\_image\_tag) | n/a | `string` | `"master-head"` | no |
+| <a name="input_rancher_password"></a> [rancher\_password](#input\_rancher\_password) | Password to set for admin user after bootstrap of Rancher Server | `string` | `""` | no |
+| <a name="input_rancher_version"></a> [rancher\_version](#input\_rancher\_version) | Version of Rancher to install - Do not include the v prefix. | `string` | n/a | yes |
+| <a name="input_registration_command"></a> [registration\_command](#input\_registration\_command) | Registration command to import cluster into Rancher. Should not be used when installing Rancher in this same cluster | `string` | `""` | no |
+| <a name="input_s3_bucket_region"></a> [s3\_bucket\_region](#input\_s3\_bucket\_region) | Optional: String that defines the AWS region of the S3 Bucket that stores the desired certs. Required if 'byo\_certs\_bucket\_path' is set. Defaults to the aws\_region if not set | `string` | `""` | no |
+| <a name="input_s3_instance_profile"></a> [s3\_instance\_profile](#input\_s3\_instance\_profile) | Optional: String that defines the name of the IAM Instance Profile that grants S3 access to the EC2 instances. Required if 'byo\_certs\_bucket\_path' is set | `string` | `""` | no |
+| <a name="input_server_image_id"></a> [server\_image\_id](#input\_server\_image\_id) | AMI to use for k3s server instances | `string` | `null` | no |
+| <a name="input_server_instance_ssh_user"></a> [server\_instance\_ssh\_user](#input\_server\_instance\_ssh\_user) | Username for sshing into instances | `string` | `"ubuntu"` | no |
+| <a name="input_server_instance_type"></a> [server\_instance\_type](#input\_server\_instance\_type) | n/a | `string` | `"m5.large"` | no |
+| <a name="input_server_k3s_exec"></a> [server\_k3s\_exec](#input\_server\_k3s\_exec) | exec args to pass to k3s server | `string` | `null` | no |
+| <a name="input_server_node_count"></a> [server\_node\_count](#input\_server\_node\_count) | Number of server nodes to launch | `number` | `1` | no |
+| <a name="input_skip_final_snapshot"></a> [skip\_final\_snapshot](#input\_skip\_final\_snapshot) | Boolean that defines whether or not the final snapshot should be created on RDS cluster deletion | `bool` | `true` | no |
+| <a name="input_ssh_keys"></a> [ssh\_keys](#input\_ssh\_keys) | SSH keys to inject into Rancher instances | `list(any)` | `[]` | no |
+| <a name="input_subdomain"></a> [subdomain](#input\_subdomain) | subdomain to host rancher on, instead of using `var.name` | `string` | `null` | no |
+| <a name="input_tls_cert_file"></a> [tls\_cert\_file](#input\_tls\_cert\_file) | Optional: String that defines the name of the TLS Certificate file in the specified S3 bucket's cert tarball. Required if 'byo\_certs\_bucket\_path' is set | `string` | `""` | no |
+| <a name="input_tls_key_file"></a> [tls\_key\_file](#input\_tls\_key\_file) | Optional: String that defines the name of the TLS Key file in the specified S3 bucket's cert tarball. Required if 'byo\_certs\_bucket\_path' is set | `string` | `""` | no |
+| <a name="input_use_new_bootstrap"></a> [use\_new\_bootstrap](#input\_use\_new\_bootstrap) | Boolean that defines whether or not utilize the new bootstrap password process used in 2.6.x | `bool` | `true` | no |
+| <a name="input_use_route53"></a> [use\_route53](#input\_use\_route53) | Configures whether to use route\_53 DNS or not | `bool` | `true` | no |
+| <a name="input_user"></a> [user](#input\_user) | n/a | `string` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The vpc id that Rancher should use | `string` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| rancher\_admin\_password |  |
-| rancher\_token |  |
-| rancher\_url |  |
-
+| <a name="output_external_lb_dns_name"></a> [external\_lb\_dns\_name](#output\_external\_lb\_dns\_name) | n/a |
+| <a name="output_k3s_cluster_secret"></a> [k3s\_cluster\_secret](#output\_k3s\_cluster\_secret) | n/a |
+| <a name="output_k3s_tls_san"></a> [k3s\_tls\_san](#output\_k3s\_tls\_san) | n/a |
+| <a name="output_kube_config"></a> [kube\_config](#output\_kube\_config) | n/a |
+| <a name="output_rancher_admin_password"></a> [rancher\_admin\_password](#output\_rancher\_admin\_password) | n/a |
+| <a name="output_rancher_token"></a> [rancher\_token](#output\_rancher\_token) | n/a |
+| <a name="output_rancher_token_id"></a> [rancher\_token\_id](#output\_rancher\_token\_id) | n/a |
+| <a name="output_rancher_url"></a> [rancher\_url](#output\_rancher\_url) | n/a |
+| <a name="output_tls_cert_file"></a> [tls\_cert\_file](#output\_tls\_cert\_file) | n/a |
+| <a name="output_tls_key_file"></a> [tls\_key\_file](#output\_tls\_key\_file) | n/a |
+| <a name="output_use_new_bootstrap"></a> [use\_new\_bootstrap](#output\_use\_new\_bootstrap) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 # License

--- a/control-plane/modules/aws-k3s/data.tf
+++ b/control-plane/modules/aws-k3s/data.tf
@@ -90,7 +90,7 @@ data "template_cloudinit_config" "k3s_server" {
       rancher_chart_tag     = local.rancher_chart_tag,
       rancher_version       = local.rancher_version,
       rancher_password      = local.rancher_password,
-      use_new_bootstrap     = local.use_new_bootstrap,
+      use_new_bootstrap     = var.use_new_bootstrap,
       rancher_node_count    = var.server_node_count,
       rancher_hostname      = "${local.subdomain}.${local.domain}",
       install_rancher       = local.install_rancher,
@@ -120,6 +120,7 @@ data "template_cloudinit_config" "k3s_server" {
 }
 
 data "template_cloudinit_config" "k3s_agent" {
+  count         = local.agent_node_count > 0 && var.create_external_nlb ? 1 : 0
   gzip          = false
   base64_encode = true
 
@@ -150,4 +151,12 @@ data "template_cloudinit_config" "k3s_agent" {
       }
     )
   }
+}
+
+data "rancher2_cluster" "local" {
+  count = local.install_rancher ? 1 : 0
+  name  = "local"
+  depends_on = [
+    rancher2_bootstrap.admin
+  ]
 }

--- a/control-plane/modules/aws-k3s/files/rancher-install.sh
+++ b/control-plane/modules/aws-k3s/files/rancher-install.sh
@@ -96,7 +96,7 @@ metadata:
   name: rancher-monitoring-crd
   namespace: kube-system
 spec:
-  chart: https://raw.githubusercontent.com/rancher/charts/${rancher_chart_tag}/assets/rancher-monitoring/rancher-monitoring-crd-${monitoring_version}.tgz
+  chart: https://raw.githubusercontent.com/rancher/charts/${rancher_chart_tag}/assets/rancher-monitoring-crd/rancher-monitoring-crd-${monitoring_version}.tgz
   targetNamespace: cattle-monitoring-system
   valuesContent: |-
     global:

--- a/control-plane/modules/aws-k3s/loadbalancer.tf
+++ b/control-plane/modules/aws-k3s/loadbalancer.tf
@@ -1,4 +1,4 @@
-resource "aws_lb" "server-lb" {
+resource "aws_lb" "server_lb" {
   name               = "${local.name}-int"
   internal           = true
   load_balancer_type = "network"
@@ -11,8 +11,8 @@ resource "aws_lb" "server-lb" {
 
 }
 
-resource "aws_lb_listener" "server-port_6443" {
-  load_balancer_arn = aws_lb.server-lb.arn
+resource "aws_lb_listener" "server_port_6443" {
+  load_balancer_arn = aws_lb.server_lb.arn
   port              = "6443"
   protocol          = "TCP"
 
@@ -45,7 +45,7 @@ resource "aws_lb" "lb" {
 
 resource "aws_lb_listener" "port_443" {
   count             = local.create_external_nlb
-  load_balancer_arn = aws_lb.lb.0.arn
+  load_balancer_arn = aws_lb.lb[0].arn
   port              = "443"
   protocol          = "TCP"
 
@@ -57,7 +57,7 @@ resource "aws_lb_listener" "port_443" {
 
 resource "aws_lb_listener" "port_80" {
   count             = local.create_external_nlb
-  load_balancer_arn = aws_lb.lb.0.arn
+  load_balancer_arn = aws_lb.lb[0].arn
   port              = "80"
   protocol          = "TCP"
 

--- a/control-plane/modules/aws-k3s/output.tf
+++ b/control-plane/modules/aws-k3s/output.tf
@@ -8,7 +8,7 @@ output "rancher_url" {
 }
 
 output "rancher_token_id" {
-  value     = rancher2_bootstrap.admin[0].token_id
+  value = rancher2_bootstrap.admin[0].token_id
 }
 
 output "rancher_token" {
@@ -16,8 +16,13 @@ output "rancher_token" {
   sensitive = false
 }
 
+output "kube_config" {
+  value     = data.rancher2_cluster.local[0].kube_config
+  sensitive = true
+}
+
 output "external_lb_dns_name" {
-  value = local.create_external_nlb > 0 ? aws_lb.lb.0.dns_name : null
+  value = local.create_external_nlb > 0 ? aws_lb.lb[0].dns_name : null
 }
 
 output "k3s_cluster_secret" {
@@ -26,11 +31,11 @@ output "k3s_cluster_secret" {
 }
 
 output "k3s_tls_san" {
-  value     = local.k3s_tls_san
+  value = local.k3s_tls_san
 }
 
 output "use_new_bootstrap" {
-  value     = local.use_new_bootstrap
+  value = var.use_new_bootstrap
 }
 
 output "tls_cert_file" {

--- a/control-plane/modules/aws-k3s/variables.tf
+++ b/control-plane/modules/aws-k3s/variables.tf
@@ -4,6 +4,12 @@ variable "rancher_password" {
   description = "Password to set for admin user after bootstrap of Rancher Server"
 }
 
+variable "use_new_bootstrap" {
+  type        = bool
+  default     = true
+  description = "Boolean that defines whether or not utilize the new bootstrap password process used in 2.6.x"
+}
+
 variable "rancher_version" {
   type        = string
   description = "Version of Rancher to install - Do not include the v prefix."
@@ -27,7 +33,7 @@ variable "server_image_id" {
 }
 
 variable "ssh_keys" {
-  type        = list
+  type        = list(any)
   default     = []
   description = "SSH keys to inject into Rancher instances"
 }
@@ -132,13 +138,13 @@ variable "aws_profile" {
 
 variable "public_subnets" {
   default     = []
-  type        = list
+  type        = list(any)
   description = "List of public subnet ids."
 }
 
 variable "private_subnets" {
   default     = []
-  type        = list
+  type        = list(any)
   description = "List of private subnet ids."
 }
 
@@ -156,19 +162,19 @@ variable "k3s_cluster_secret" {
 
 variable "extra_server_security_groups" {
   default     = []
-  type        = list
+  type        = list(any)
   description = "Additional security groups to attach to k3s server instances"
 }
 
 variable "extra_agent_security_groups" {
   default     = []
-  type        = list
+  type        = list(any)
   description = "Additional security groups to attach to k3s agent instances"
 }
 
 variable "aws_azs" {
   default     = null
-  type        = list
+  type        = list(any)
   description = "List of AWS Availability Zones in the VPC"
 }
 
@@ -198,13 +204,13 @@ variable "db_security_group" {
 
 variable "private_subnets_cidr_blocks" {
   default     = []
-  type        = list
+  type        = list(any)
   description = "List of cidr_blocks of private subnets"
 }
 
 variable "public_subnets_cidr_blocks" {
   default     = []
-  type        = list
+  type        = list(any)
   description = "List of cidr_blocks of public subnets"
 }
 

--- a/control-plane/modules/generate-kube-config/README.md
+++ b/control-plane/modules/generate-kube-config/README.md
@@ -1,0 +1,39 @@
+# generate-kube-config
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_local"></a> [local](#provider\_local) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [local_file.kubeconfig](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_identifier_prefix"></a> [identifier\_prefix](#input\_identifier\_prefix) | n/a | `any` | n/a | yes |
+| <a name="input_kubeconfig_content"></a> [kubeconfig\_content](#input\_kubeconfig\_content) | n/a | `any` | n/a | yes |
+| <a name="input_kubeconfig_dir"></a> [kubeconfig\_dir](#input\_kubeconfig\_dir) | n/a | `any` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_kubeconfig_path"></a> [kubeconfig\_path](#output\_kubeconfig\_path) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/control-plane/modules/generate-kube-config/main.tf
+++ b/control-plane/modules/generate-kube-config/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+  }
+}
+
+locals {
+  kubeconfig_path = "${var.kubeconfig_dir}/.${var.identifier_prefix}-tfkubeconfig"
+}
+
+resource "local_file" "kubeconfig" {
+  content  = var.kubeconfig_content
+  filename = local.kubeconfig_path
+}
+
+# resource "null_resource" "save_kubeconfig" {
+#   provisioner "local-exec" {
+#     command = "echo \"${var.kubeconfig_content}\" > ${local.kubeconfig_path}-copy"
+#   }
+# }

--- a/control-plane/modules/generate-kube-config/outputs.tf
+++ b/control-plane/modules/generate-kube-config/outputs.tf
@@ -1,0 +1,3 @@
+output "kubeconfig_path" {
+  value = local.kubeconfig_path
+}

--- a/control-plane/modules/generate-kube-config/variables.tf
+++ b/control-plane/modules/generate-kube-config/variables.tf
@@ -1,0 +1,11 @@
+variable "kubeconfig_content" {
+
+}
+
+variable "kubeconfig_dir" {
+
+}
+
+variable "identifier_prefix" {
+
+}

--- a/control-plane/modules/install-common/README.md
+++ b/control-plane/modules/install-common/README.md
@@ -1,0 +1,65 @@
+# install-common
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_helm"></a> [helm](#provider\_helm) | n/a |
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
+| <a name="provider_rancher2"></a> [rancher2](#provider\_rancher2) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [helm_release.cert_manager](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.rancher](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [null_resource.wait_for_cert_manager](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.wait_for_rancher](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [rancher2_bootstrap.admin](https://registry.terraform.io/providers/rancher/rancher2/latest/docs/resources/bootstrap) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_byo_certs_bucket_path"></a> [byo\_certs\_bucket\_path](#input\_byo\_certs\_bucket\_path) | Optional: String that defines the path on the S3 Bucket where your certs are stored. NOTE: assumes certs are stored in a tarball within a folder below the top-level bucket e.g.: my-bucket/certificates/my\_certs.tar.gz. Certs should be stored within a single folder, certs nested in sub-folders will not be handled | `string` | `""` | no |
+| <a name="input_certmanager_version"></a> [certmanager\_version](#input\_certmanager\_version) | Version of cert-manager to install | `string` | `"1.5.3"` | no |
+| <a name="input_client_certificate"></a> [client\_certificate](#input\_client\_certificate) | K8s cluster client certificate | `string` | `null` | no |
+| <a name="input_client_key"></a> [client\_key](#input\_client\_key) | K8s cluster client key | `string` | `null` | no |
+| <a name="input_cluster_ca_certificate"></a> [cluster\_ca\_certificate](#input\_cluster\_ca\_certificate) | K8s cluster CA certificate | `string` | `null` | no |
+| <a name="input_cluster_host_url"></a> [cluster\_host\_url](#input\_cluster\_host\_url) | K8s cluster api server url | `string` | `null` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | n/a | `string` | `null` | no |
+| <a name="input_helm_rancher_chart_values_path"></a> [helm\_rancher\_chart\_values\_path](#input\_helm\_rancher\_chart\_values\_path) | Local path to the templated values.yaml to be used for the Rancher Server Helm install | `string` | `null` | no |
+| <a name="input_helm_rancher_repo"></a> [helm\_rancher\_repo](#input\_helm\_rancher\_repo) | The repo URL to use for Rancher Server charts | `string` | `"https://releases.rancher.com/server-charts/latest"` | no |
+| <a name="input_install_certmanager"></a> [install\_certmanager](#input\_install\_certmanager) | Boolean that defines whether or not to install Cert-Manager | `bool` | `true` | no |
+| <a name="input_install_rancher"></a> [install\_rancher](#input\_install\_rancher) | Boolean that defines whether or not to install Rancher | `bool` | `true` | no |
+| <a name="input_kube_config_path"></a> [kube\_config\_path](#input\_kube\_config\_path) | Path to kubeconfig file on local machine | `string` | `null` | no |
+| <a name="input_letsencrypt_email"></a> [letsencrypt\_email](#input\_letsencrypt\_email) | LetsEncrypt email address to use | `string` | `"none@none.com"` | no |
+| <a name="input_private_ca_file"></a> [private\_ca\_file](#input\_private\_ca\_file) | Optional: String that defines the name of the private CA .pem file in the specified S3 bucket's cert tarball | `string` | `""` | no |
+| <a name="input_rancher_image"></a> [rancher\_image](#input\_rancher\_image) | n/a | `string` | `"rancher/rancher"` | no |
+| <a name="input_rancher_image_tag"></a> [rancher\_image\_tag](#input\_rancher\_image\_tag) | Rancher image tag to install, this can differ from rancher\_version which is the chart being used to install Rancher | `string` | `"release/v2.6"` | no |
+| <a name="input_rancher_node_count"></a> [rancher\_node\_count](#input\_rancher\_node\_count) | n/a | `number` | `1` | no |
+| <a name="input_rancher_password"></a> [rancher\_password](#input\_rancher\_password) | Password to set for admin user during bootstrap of Rancher Server, if not set random password will be generated | `string` | `""` | no |
+| <a name="input_rancher_version"></a> [rancher\_version](#input\_rancher\_version) | Version of Rancher to install - Do not include the v prefix. | `string` | n/a | yes |
+| <a name="input_s3_bucket_region"></a> [s3\_bucket\_region](#input\_s3\_bucket\_region) | Optional: String that defines the AWS region of the S3 Bucket that stores the desired certs. Required if 'byo\_certs\_bucket\_path' is set. Defaults to the aws\_region if not set | `string` | `""` | no |
+| <a name="input_subdomain"></a> [subdomain](#input\_subdomain) | subdomain to host rancher on | `string` | `null` | no |
+| <a name="input_tls_cert_file"></a> [tls\_cert\_file](#input\_tls\_cert\_file) | Optional: String that defines the name of the TLS Certificate file in the specified S3 bucket's cert tarball. Required if 'byo\_certs\_bucket\_path' is set | `string` | `""` | no |
+| <a name="input_tls_key_file"></a> [tls\_key\_file](#input\_tls\_key\_file) | Optional: String that defines the name of the TLS Key file in the specified S3 bucket's cert tarball. Required if 'byo\_certs\_bucket\_path' is set | `string` | `""` | no |
+| <a name="input_use_new_bootstrap"></a> [use\_new\_bootstrap](#input\_use\_new\_bootstrap) | Boolean that defines whether or not utilize the new bootstrap password process used in 2.6.x | `bool` | `true` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_rancher_token"></a> [rancher\_token](#output\_rancher\_token) | n/a |
+| <a name="output_rancher_url"></a> [rancher\_url](#output\_rancher\_url) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/control-plane/modules/install-common/main.tf
+++ b/control-plane/modules/install-common/main.tf
@@ -1,0 +1,120 @@
+terraform {
+  required_providers {
+    rancher2 = {
+      source = "rancher/rancher2"
+    }
+    rke = {
+      source = "rancher/rke"
+    }
+    helm = {
+      source = "hashicorp/helm"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+}
+
+resource "helm_release" "cert_manager" {
+  count            = var.install_certmanager ? 1 : 0
+  name             = "cert-manager"
+  repository       = "https://charts.jetstack.io"
+  chart            = "cert-manager"
+  version          = var.certmanager_version
+  namespace        = "cert-manager"
+  create_namespace = true
+
+  set {
+    name  = "installCRDs"
+    value = "true"
+  }
+}
+
+resource "null_resource" "wait_for_cert_manager" {
+  count = var.install_certmanager ? 1 : 0
+  provisioner "local-exec" {
+    command = <<-EOT
+    timeout --preserve-status 5m sh -c -- 'until [ "$${pods}" = "3" ]; do
+      sleep 5
+      pods="$(kubectl get pods --namespace cert-manager | grep Running | wc -l | awk '\''{$1=$1;print}'\'')"
+      echo "cert-manager pods: $${pods}"
+    done'
+    EOT
+    environment = {
+      KUBECONFIG = "${var.kube_config_path}"
+    }
+  }
+
+  depends_on = [
+    helm_release.cert_manager
+  ]
+}
+
+resource "helm_release" "rancher" {
+  count            = var.install_rancher ? 1 : 0
+  name             = "rancher"
+  repository       = var.helm_rancher_repo
+  chart            = "rancher"
+  version          = var.rancher_version
+  devel            = true
+  namespace        = "cattle-system"
+  create_namespace = true
+  values = [
+    templatefile("${var.helm_rancher_chart_values_path}", {
+      letsencrypt_email   = var.letsencrypt_email
+      rancher_image       = var.rancher_image
+      rancher_image_tag   = var.rancher_image_tag
+      rancher_password    = var.rancher_password
+      use_new_bootstrap   = var.use_new_bootstrap
+      rancher_node_count  = var.rancher_node_count
+      rancher_hostname    = "${var.subdomain}.${var.domain}"
+      install_certmanager = var.install_certmanager
+      install_byo_certs   = length(var.byo_certs_bucket_path) > 0 ? true : false
+      private_ca          = length(var.private_ca_file) > 0 ? true : false
+      }
+    )
+  ]
+  depends_on = [
+    null_resource.wait_for_cert_manager
+  ]
+}
+
+resource "null_resource" "wait_for_rancher" {
+  count = var.install_rancher ? 1 : 0
+  provisioner "local-exec" {
+    command = <<-EOT
+    kubectl -n cattle-system rollout status deploy/rancher
+    timeout --preserve-status 7m sh -c -- 'until echo "$${subject}" | grep -q "CN=${var.subdomain}.${var.domain}" || echo "$${subject}" | grep -q "CN=\*.${var.domain}" ; do
+        sleep 5
+        subject=$(curl -vk -m 2 "https://${var.subdomain}.${var.domain}/ping" 2>&1 | grep "subject:")
+        echo "Subject: $${subject}"
+    done'
+    timeout --preserve-status 2m sh -c -- 'while [ "$${resp}" != "pong" ]; do
+        resp=$(curl -sSk -m 2 "https://${var.subdomain}.${var.domain}/ping")
+        echo "Rancher Response: $${resp}"
+        if [ "$${resp}" != "pong" ]; then
+          sleep 10
+        fi
+    done'
+    EOT
+
+    environment = {
+      KUBECONFIG       = "${var.kube_config_path}"
+      RANCHER_HOSTNAME = "${var.subdomain}.${var.domain}"
+    }
+  }
+
+  depends_on = [
+    helm_release.rancher
+  ]
+}
+
+resource "rancher2_bootstrap" "admin" {
+  count            = (var.install_rancher) ? 1 : 0
+  initial_password = var.use_new_bootstrap ? var.rancher_password : null
+  password         = var.rancher_password
+  depends_on       = [null_resource.wait_for_rancher]
+}

--- a/control-plane/modules/install-common/main.tf
+++ b/control-plane/modules/install-common/main.tf
@@ -41,7 +41,8 @@ resource "null_resource" "wait_for_cert_manager" {
       sleep 5
       pods="$(kubectl get pods --namespace cert-manager | grep Running | wc -l | awk '\''{$1=$1;print}'\'')"
       echo "cert-manager pods: $${pods}"
-    done'
+    done
+    sleep 60'
     EOT
     environment = {
       KUBECONFIG = "${var.kube_config_path}"

--- a/control-plane/modules/install-common/main.tf
+++ b/control-plane/modules/install-common/main.tf
@@ -41,8 +41,8 @@ resource "null_resource" "wait_for_cert_manager" {
       sleep 5
       pods="$(kubectl get pods --namespace cert-manager | grep Running | wc -l | awk '\''{$1=$1;print}'\'')"
       echo "cert-manager pods: $${pods}"
-    done
-    sleep 60'
+    done'
+    sleep 60
     EOT
     environment = {
       KUBECONFIG = "${var.kube_config_path}"

--- a/control-plane/modules/install-common/output.tf
+++ b/control-plane/modules/install-common/output.tf
@@ -1,0 +1,8 @@
+output "rancher_url" {
+  value = rancher2_bootstrap.admin[0].url
+}
+
+output "rancher_token" {
+  value     = rancher2_bootstrap.admin[0].token
+  sensitive = true
+}

--- a/control-plane/modules/install-common/variables.tf
+++ b/control-plane/modules/install-common/variables.tf
@@ -1,0 +1,140 @@
+variable "kube_config_path" {
+  default     = null
+  type        = string
+  description = "Path to kubeconfig file on local machine"
+}
+
+variable "cluster_host_url" {
+  default     = null
+  type        = string
+  description = "K8s cluster api server url"
+}
+
+variable "client_certificate" {
+  default     = null
+  type        = string
+  description = "K8s cluster client certificate"
+}
+
+variable "client_key" {
+  default     = null
+  type        = string
+  description = "K8s cluster client key"
+}
+
+variable "cluster_ca_certificate" {
+  default     = null
+  type        = string
+  description = "K8s cluster CA certificate"
+}
+
+variable "install_certmanager" {
+  default     = true
+  type        = bool
+  description = "Boolean that defines whether or not to install Cert-Manager"
+}
+
+variable "install_rancher" {
+  default     = true
+  type        = bool
+  description = "Boolean that defines whether or not to install Rancher"
+}
+
+variable "helm_rancher_repo" {
+  type        = string
+  default     = "https://releases.rancher.com/server-charts/latest"
+  description = "The repo URL to use for Rancher Server charts"
+}
+
+variable "helm_rancher_chart_values_path" {
+  type        = string
+  default     = null
+  description = "Local path to the templated values.yaml to be used for the Rancher Server Helm install"
+
+}
+
+variable "letsencrypt_email" {
+  type        = string
+  default     = "none@none.com"
+  description = "LetsEncrypt email address to use"
+}
+
+variable "rancher_image" {
+  type    = string
+  default = "rancher/rancher"
+}
+
+variable "rancher_image_tag" {
+  type        = string
+  default     = "release/v2.6"
+  description = "Rancher image tag to install, this can differ from rancher_version which is the chart being used to install Rancher"
+}
+
+variable "rancher_node_count" {
+  type    = number
+  default = 1
+}
+
+variable "subdomain" {
+  default     = null
+  type        = string
+  description = "subdomain to host rancher on"
+}
+
+variable "domain" {
+  type    = string
+  default = null
+}
+
+variable "rancher_password" {
+  type        = string
+  default     = ""
+  description = "Password to set for admin user during bootstrap of Rancher Server, if not set random password will be generated"
+}
+
+variable "use_new_bootstrap" {
+  type        = bool
+  default     = true
+  description = "Boolean that defines whether or not utilize the new bootstrap password process used in 2.6.x"
+}
+
+variable "rancher_version" {
+  type        = string
+  description = "Version of Rancher to install - Do not include the v prefix."
+}
+
+variable "certmanager_version" {
+  type        = string
+  default     = "1.5.3"
+  description = "Version of cert-manager to install"
+}
+
+variable "byo_certs_bucket_path" {
+  default     = ""
+  type        = string
+  description = "Optional: String that defines the path on the S3 Bucket where your certs are stored. NOTE: assumes certs are stored in a tarball within a folder below the top-level bucket e.g.: my-bucket/certificates/my_certs.tar.gz. Certs should be stored within a single folder, certs nested in sub-folders will not be handled"
+}
+
+variable "s3_bucket_region" {
+  default     = ""
+  type        = string
+  description = "Optional: String that defines the AWS region of the S3 Bucket that stores the desired certs. Required if 'byo_certs_bucket_path' is set. Defaults to the aws_region if not set"
+}
+
+variable "private_ca_file" {
+  default     = ""
+  type        = string
+  description = "Optional: String that defines the name of the private CA .pem file in the specified S3 bucket's cert tarball"
+}
+
+variable "tls_cert_file" {
+  default     = ""
+  type        = string
+  description = "Optional: String that defines the name of the TLS Certificate file in the specified S3 bucket's cert tarball. Required if 'byo_certs_bucket_path' is set"
+}
+
+variable "tls_key_file" {
+  default     = ""
+  type        = string
+  description = "Optional: String that defines the name of the TLS Key file in the specified S3 bucket's cert tarball. Required if 'byo_certs_bucket_path' is set"
+}

--- a/control-plane/modules/rke1/README.md
+++ b/control-plane/modules/rke1/README.md
@@ -1,0 +1,49 @@
+# rke1
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_rke"></a> [rke](#provider\_rke) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [rke_cluster.local](https://registry.terraform.io/providers/rancher/rke/latest/docs/resources/cluster) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | n/a | `any` | n/a | yes |
+| <a name="input_install_docker_version"></a> [install\_docker\_version](#input\_install\_docker\_version) | Version of Docker to install | `string` | `"20.10"` | no |
+| <a name="input_install_k8s_version"></a> [install\_k8s\_version](#input\_install\_k8s\_version) | Version of K8s to install | `string` | n/a | yes |
+| <a name="input_nodes_ids"></a> [nodes\_ids](#input\_nodes\_ids) | Node IDs of the desired nodes for the RKE HA setup | `list(string)` | n/a | yes |
+| <a name="input_nodes_private_ips"></a> [nodes\_private\_ips](#input\_nodes\_private\_ips) | Private IP addresses of the desired nodes for the RKE HA setup | `list(string)` | n/a | yes |
+| <a name="input_nodes_public_ips"></a> [nodes\_public\_ips](#input\_nodes\_public\_ips) | Public IP addresses of the desired nodes for the RKE HA setup | `list(string)` | n/a | yes |
+| <a name="input_s3_instance_profile"></a> [s3\_instance\_profile](#input\_s3\_instance\_profile) | Optional: String that defines the name of the IAM Instance Profile that grants S3 access to the EC2 instances. Required if 'byo\_certs\_bucket\_path' is set | `string` | `""` | no |
+| <a name="input_server_node_count"></a> [server\_node\_count](#input\_server\_node\_count) | n/a | `any` | n/a | yes |
+| <a name="input_ssh_key_path"></a> [ssh\_key\_path](#input\_ssh\_key\_path) | Path to the ssh\_key file to be used for connecting to the nodes | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_api_server_url"></a> [api\_server\_url](#output\_api\_server\_url) | n/a |
+| <a name="output_ca_crt"></a> [ca\_crt](#output\_ca\_crt) | n/a |
+| <a name="output_client_cert"></a> [client\_cert](#output\_client\_cert) | n/a |
+| <a name="output_client_key"></a> [client\_key](#output\_client\_key) | n/a |
+| <a name="output_cluster_yaml"></a> [cluster\_yaml](#output\_cluster\_yaml) | n/a |
+| <a name="output_kube_config"></a> [kube\_config](#output\_kube\_config) | n/a |
+| <a name="output_rke_cluster"></a> [rke\_cluster](#output\_rke\_cluster) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/control-plane/modules/rke1/main.tf
+++ b/control-plane/modules/rke1/main.tf
@@ -1,0 +1,121 @@
+terraform {
+  required_providers {
+    rke = {
+      source = "rancher/rke"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+}
+
+locals {
+  s3_instance_profile         = var.s3_instance_profile
+  node_ids                    = var.nodes_ids
+  node_public_ips             = var.nodes_public_ips
+  node_private_ips            = var.nodes_private_ips
+  rancher_reserved_node_ids   = slice(local.node_ids, 1, var.server_node_count + 1)
+  rancher_node_public_ips     = slice(local.node_public_ips, 1, var.server_node_count + 1)
+  rancher_node_private_ips    = slice(local.node_private_ips, 1, var.server_node_count + 1)
+  monitoring_reserved_node_id = var.nodes_ids[0]
+  monitoring_node_public_ip   = var.nodes_public_ips[0]
+  monitoring_node_private_ip  = var.nodes_private_ips[0]
+}
+
+resource "rke_cluster" "local" {
+  cluster_name = var.cluster_name
+  cloud_provider {
+    name = "aws"
+    aws_cloud_provider {}
+  }
+  ### Nodes Reserved for Rancher ###
+  dynamic "nodes" {
+    for_each = toset(local.rancher_reserved_node_ids)
+    # iterator = "node_id"
+    content {
+      address          = local.rancher_node_public_ips[index(local.rancher_reserved_node_ids, nodes.key)]
+      internal_address = local.rancher_node_private_ips[index(local.rancher_reserved_node_ids, nodes.key)]
+      user             = "ubuntu"
+      role             = ["controlplane", "worker", "etcd"]
+      # ssh_key_path     = var.ssh_key_path
+    }
+  }
+  ### Node Reserved for Monitoring ###
+  nodes {
+    address          = local.monitoring_node_public_ip
+    internal_address = local.monitoring_node_private_ip
+    user             = "ubuntu"
+    role             = ["controlplane", "worker", "etcd"]
+    # ssh_key_path     = var.ssh_key_path
+    taints {
+      # taint {
+      key    = "monitoring"
+      value  = "yes"
+      effect = "NoSchedule"
+      # }
+    }
+    labels = {
+      monitoring = "yes"
+    }
+  }
+  #  SSH key to access all hosts in your cluster
+  ssh_key_path          = var.ssh_key_path
+  ignore_docker_version = false
+  # Set kubernetes version to install: https://rancher.com/docs/rke/latest/en/upgrades/#listing-supported-kubernetes-versions
+  # Check with -> rke config --list-version --all
+  kubernetes_version = length(var.install_k8s_version) > 0 ? var.install_k8s_version : null
+  # Etcd snapshots
+  services {
+    etcd {
+      backup_config {
+        interval_hours = 12
+        retention      = 6
+      }
+      snapshot  = true
+      creation  = "6h"
+      retention = "24h"
+    }
+  }
+
+  # Configure  network plug-ins
+  # KE provides the following network plug-ins that are deployed as add-ons: flannel, calico, weave, and canal
+  # After you launch the cluster, you cannot change your network provider.
+  # Setting the network plug-in
+  # network {
+  #   plugin = "canal"
+  #   options = {
+  #     "canal_flannel_backend_type" = "vxlan"
+  #   }
+  # }
+
+  # Specify DNS provider (coredns or kube-dns)
+  # dns {
+  #   provider = "coredns"
+  # }
+
+  # Currently, only authentication strategy supported is x509.
+  # You can optionally create additional SANs (hostnames or IPs) to
+  # add to the API server PKI certificate.
+  # This is useful if you want to use a load balancer for the
+  # control plane servers.
+  # authentication {
+  #   strategy = "x509"
+  #   sans     = [local.rke1_tls_san]
+  # }
+
+  # Currently only nginx ingress provider is supported.
+  # To disable ingress controller, set `provider: none`
+  # `node_selector` controls ingress placement and is optional
+  #   ingress {
+  #     provider = "nginx"
+  #     options = {
+  #       "use-forwarded-headers" = "true"
+  #     }
+  #   }
+}

--- a/control-plane/modules/rke1/output.tf
+++ b/control-plane/modules/rke1/output.tf
@@ -1,0 +1,31 @@
+output "kube_config" {
+  value = rke_cluster.local.kube_config_yaml
+}
+
+output "cluster_yaml" {
+  value = rke_cluster.local.rke_cluster_yaml
+}
+
+output "api_server_url" {
+  value = rke_cluster.local.api_server_url
+}
+
+output "client_cert" {
+  value     = rke_cluster.local.client_cert
+  sensitive = false
+}
+
+output "client_key" {
+  value     = rke_cluster.local.client_key
+  sensitive = false
+}
+
+output "ca_crt" {
+  value     = rke_cluster.local.ca_crt
+  sensitive = false
+}
+
+output "rke_cluster" {
+  value     = rke_cluster.local
+  sensitive = false
+}

--- a/control-plane/modules/rke1/variables.tf
+++ b/control-plane/modules/rke1/variables.tf
@@ -1,7 +1,13 @@
 variable "cluster_name" {
+  type        = string
+  default     = "local"
+  description = "Name of the cluster within Rancher2"
 }
 
-variable "server_node_count" {
+variable "hostname_override_prefix" {
+  type        = string
+  default     = ""
+  description = "String to prepend to the hostname_override field for each node. (Ignored for AWS cloud provider)"
 }
 
 variable "install_docker_version" {

--- a/control-plane/modules/rke1/variables.tf
+++ b/control-plane/modules/rke1/variables.tf
@@ -1,0 +1,43 @@
+variable "cluster_name" {
+}
+
+variable "server_node_count" {
+}
+
+variable "install_docker_version" {
+  type        = string
+  default     = "20.10"
+  description = "Version of Docker to install"
+}
+
+variable "install_k8s_version" {
+  type        = string
+  description = "Version of K8s to install"
+}
+
+variable "s3_instance_profile" {
+  default     = ""
+  type        = string
+  description = "Optional: String that defines the name of the IAM Instance Profile that grants S3 access to the EC2 instances. Required if 'byo_certs_bucket_path' is set"
+}
+
+variable "nodes_ids" {
+  type        = list(string)
+  description = "Node IDs of the desired nodes for the RKE HA setup"
+}
+
+variable "nodes_public_ips" {
+  type        = list(string)
+  description = "Public IP addresses of the desired nodes for the RKE HA setup"
+}
+
+variable "nodes_private_ips" {
+  type        = list(string)
+  description = "Private IP addresses of the desired nodes for the RKE HA setup"
+}
+
+variable "ssh_key_path" {
+  default     = null
+  type        = string
+  description = "Path to the ssh_key file to be used for connecting to the nodes"
+}

--- a/control-plane/outputs.tf
+++ b/control-plane/outputs.tf
@@ -1,76 +1,85 @@
-output "identity" {
-  value = local.identifier
-}
 /*
 output "db_instance_address" {
   description = "The address of the RDS instance"
-  value       = module.db.this_db_instance_address
+  value       = var.k8s_distribution == "k3s" ? module.db[0].this_db_instance_address : null
 }
 
 output "db_instance_arn" {
   description = "The ARN of the RDS instance"
-  value       = module.db.this_db_instance_arn
+  value       = var.k8s_distribution == "k3s" ? module.db[0].this_db_instance_arn : null
 }
 */
 
 output "db_instance_availability_zone" {
   description = "The availability zone of the RDS instance"
-  value       = module.db.db_instance_availability_zone
+  value       = var.k8s_distribution == "k3s" ? module.db[0].db_instance_availability_zone : null
 }
 
 output "db_instance_endpoint" {
   description = "The connection endpoint"
-  value       = module.db.db_instance_endpoint
+  value       = var.k8s_distribution == "k3s" ? module.db[0].db_instance_endpoint : null
 }
 
 /*
 output "db_instance_id" {
   description = "The RDS instance ID"
-  value       = module.db.this_db_instance_id
+  value       = var.k8s_distribution == "k3s" ? module.db[0].this_db_instance_id : null
 }
 */
 
+output "k8s_distribtion" {
+  value = var.k8s_distribution
+}
+
 output "rancher_admin_password" {
-  value     = module.k3s.rancher_admin_password
+  value     = var.rancher_password
   sensitive = true
 }
 
 output "rancher_url" {
-  value = module.k3s.rancher_url
+  value = var.k8s_distribution == "k3s" ? module.k3s[0].rancher_url : module.install_common[0].rancher_url
 }
 
 output "rancher_token" {
-  value     = var.sensitive_token ? null : nonsensitive(module.k3s.rancher_token)
+  value     = var.k8s_distribution == "k3s" ? var.sensitive_token ? null : nonsensitive(module.k3s[0].rancher_token) : var.sensitive_token ? null : nonsensitive(module.install_common[0].rancher_token)
   sensitive = false
 }
 
 output "external_lb_dns_name" {
-  value = module.k3s.external_lb_dns_name
+  value = var.k8s_distribution == "k3s" ? module.k3s[0].external_lb_dns_name : null
 }
 
 output "k3s_cluster_secret" {
-  value     = module.k3s.k3s_cluster_secret
+  value     = var.k8s_distribution == "k3s" ? module.k3s[0].k3s_cluster_secret : null
   sensitive = true
 }
 
 output "k3s_tls_san" {
-  value = module.k3s.k3s_tls_san
+  value = var.k8s_distribution == "k3s" ? module.k3s[0].k3s_tls_san : null
 }
 
 output "db_engine_version" {
-  value = var.db_engine_version
+  value = var.k8s_distribution == "k3s" ? var.db_engine_version : null
 }
 
 output "db_skip_final_snapshot" {
-  value = var.db_skip_final_snapshot
+  value = var.k8s_distribution == "k3s" ? var.db_skip_final_snapshot : null
 }
 
 output "server_k3s_exec" {
-  value = var.server_k3s_exec
+  value = var.k8s_distribution == "k3s" ? var.server_k3s_exec : null
+}
+
+output "install_rancher" {
+  value = var.install_rancher
 }
 
 output "install_certmanager" {
   value = var.install_certmanager
+}
+
+output "install_monitoring" {
+  value = var.install_monitoring
 }
 
 output "certmanager_version" {
@@ -78,21 +87,21 @@ output "certmanager_version" {
 }
 
 output "tls_cert_file" {
-  value     = module.k3s.tls_cert_file
+  value     = var.tls_cert_file
   sensitive = true
 }
 
 output "tls_key_file" {
-  value     = module.k3s.tls_key_file
+  value     = var.tls_key_file
   sensitive = true
 }
 
-output "random_prefix" {
-  value = var.random_prefix
+output "rancher_charts_repo" {
+  value = var.install_monitoring ? var.rancher_charts_repo : null
 }
 
-output "rancher_chart_tag" {
-  value = var.rancher_chart_tag
+output "rancher_charts_branch" {
+  value = var.install_monitoring ? var.rancher_charts_branch : null
 }
 
 output "rancher_version" {
@@ -100,5 +109,10 @@ output "rancher_version" {
 }
 
 output "use_new_bootstrap" {
-  value = module.k3s.use_new_bootstrap
+  value = local.use_new_bootstrap
 }
+
+# output "rke_cluster_yaml" {
+#   value     = var.k8s_distribution == "rke1" ? nonsensitive(module.rke1[0].cluster_yaml) : null
+#   sensitive = false
+# }

--- a/control-plane/provider.tf
+++ b/control-plane/provider.tf
@@ -1,0 +1,36 @@
+provider "aws" {
+  region  = local.aws_region
+  profile = "rancher-eng"
+}
+
+provider "aws" {
+  region  = local.aws_region
+  profile = "rancher-eng"
+  alias   = "r53"
+}
+
+provider "rancher2" {
+  alias     = "bootstrap"
+  api_url   = "https://${local.name}.${local.domain}"
+  insecure  = length(var.byo_certs_bucket_path) > 0 ? true : false
+  bootstrap = true
+}
+
+provider "rke" {
+  debug = true
+  # log_file = var.k8s_distribution == "rke1" ? "${path.module}/files/${local.name}_${terraform.workspace}_rke1_logs.txt" : null
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = abspath(module.generate_kube_config.kubeconfig_path)
+  }
+}
+
+provider "rancher2" {
+  alias     = "admin"
+  api_url   = var.k8s_distribution == "rke1" ? module.install_common[0].rancher_url : module.k3s[0].rancher_url
+  token_key = var.k8s_distribution == "rke1" ? module.install_common[0].rancher_token : module.k3s[0].rancher_token
+  insecure  = length(var.byo_certs_bucket_path) > 0 ? true : false
+  timeout   = "300s"
+}

--- a/control-plane/variables.tf
+++ b/control-plane/variables.tf
@@ -1,11 +1,41 @@
+variable "install_docker_version" {
+  type        = string
+  default     = "20.10"
+  description = "Version of Docker to install"
+}
+
+variable "install_k8s_version" {
+  type        = string
+  default     = "1.21.7-rancher1-1"
+  description = "Version of K8s to install"
+}
+
+variable "install_rancher" {
+  type        = bool
+  default     = true
+  description = "Boolean that defines whether or not to install Rancher"
+}
+
 variable "rancher_version" {
   type        = string
   description = "Version of Rancher to install - Do not include the v prefix."
 }
 
+variable "install_monitoring" {
+  type        = bool
+  default     = true
+  description = "Boolean that defines whether or not to install rancher-monitoring"
+}
+
 variable "monitoring_version" {
   type        = string
   description = "Version of Monitoring v2 to install - Do not include the v prefix."
+}
+
+variable "monitoring_chart_values_path" {
+  type        = string
+  default     = null
+  description = "Path to custom values.yaml for rancher-monitoring"
 }
 
 variable "rancher_instance_type" {
@@ -113,8 +143,8 @@ variable "db_username" {
 }
 
 variable "db_password" {
-  default = "rancher12345"
-  type    = string
+  default     = "rancher12345"
+  type        = string
   description = "Password string for database, must be >= 8 characters. Only printable ASCII characters are allowed, the following are not allowed: '/@\" ' "
 }
 
@@ -130,9 +160,15 @@ variable "db_subnet_group_name" {
 }
 
 variable "ssh_keys" {
-  type        = list
+  type        = list(any)
   default     = []
   description = "SSH keys to inject into Rancher instances"
+}
+
+variable "ssh_key_path" {
+  default     = null
+  type        = string
+  description = "Path to the private SSH key file to be used for connecting to the node(s)"
 }
 
 variable "rancher_image" {
@@ -149,6 +185,11 @@ variable "rancher_image_tag" {
 variable "rancher_node_count" {
   type    = number
   default = 1
+}
+
+variable "k8s_distribution" {
+  type        = string
+  description = "The K8s distribution to use for setting up Rancher (k3s or rke1)"
 }
 
 variable "install_k3s_version" {
@@ -177,14 +218,20 @@ variable "server_k3s_exec" {
 
 variable "rancher_chart" {
   type        = string
-  default     = "rancher-stable/rancher"
+  default     = "stable"
   description = "Helm chart to use for Rancher install"
 }
 
-variable "rancher_chart_tag" {
+variable "rancher_charts_repo" {
   type        = string
-  default     = "release-v2.5"
-  description = "The github tag for the desired Rancher chart version"
+  default     = ""
+  description = "The URL for the desired Rancher charts"
+}
+
+variable "rancher_charts_branch" {
+  type        = string
+  default     = "release-v2.6"
+  description = "The github branch for the desired Rancher chart version"
 }
 
 variable "letsencrypt_email" {
@@ -210,7 +257,7 @@ variable "r53_domain" {
 }
 
 variable "sensitive_token" {
-  type = bool
-  default = true
+  type        = bool
+  default     = true
   description = "Boolean that determines if the module should treat the generated Rancher Admin API Token as sensitive in the output."
 }


### PR DESCRIPTION
These changes add 4 new modules to the control-plane root module:

- aws-infra: a generalized infrastructure module specific to AWS (not reliant on a specific K8s distribution
  - Intentended to be built upon/added to in order to support any/all K8s distributions we may want to test against going forward
- rke1: a module for setting up an rke cluster using the `rke` terraform provider
  - Currently assumes an AWS infra, but is intended to be updated to be cloud provider-agnostic
- generate-kube-config: self-explanatory, a module for generating a local kube-config file
- install-common: a module for installing cert-manager and rancher using the `helm` terraform provider
  - This may become the default method of installing the Rancher Server for all K8s distributions in the future
 
 Moved root control-plane module providers into providers.tf and data into data.tf.
 
 README.md files have been added for each added module and the control-plane README.md has been updated as well.
 
 Additionally, the `rancher2.admin` terraform provider is being used to install rancher-monitoring for rke1 K8s clusters. Rather than using the `helm` provider, this may become the default method of installing Rancher charts via terraform for all K8s distributions in the future.