### PR TITLE
Add a RKE1-specific control-plane module that utilizes a locally installed rke binary

### DIFF
--- a/rke1-local-control-plane/.terraform.lock.hcl
+++ b/rke1-local-control-plane/.terraform.lock.hcl
@@ -1,0 +1,155 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.23.0"
+  hashes = [
+    "h1:JDJLmKK61GLw8gHQtCzmvlwPNZIu46/M5uBg/TDlBa0=",
+    "h1:j6RGCfnoLBpzQVOKUbGyxf4EJtRvQClKplO+WdXL5O0=",
+    "zh:17adbedc9a80afc571a8de7b9bfccbe2359e2b3ce1fffd02b456d92248ec9294",
+    "zh:23d8956b031d78466de82a3d2bbe8c76cc58482c931af311580b8eaef4e6a38f",
+    "zh:343fe19e9a9f3021e26f4af68ff7f4828582070f986b6e5e5b23d89df5514643",
+    "zh:6b8ff83d884b161939b90a18a4da43dd464c4b984f54b5f537b2870ce6bd94bc",
+    "zh:7777d614d5e9d589ad5508eecf4c6d8f47d50fcbaf5d40fa7921064240a6b440",
+    "zh:82f4578861a6fd0cde9a04a1926920bd72d993d524e5b34d7738d4eff3634c44",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a08fefc153bbe0586389e814979cf7185c50fcddbb2082725991ed02742e7d1e",
+    "zh:ae789c0e7cb777d98934387f8888090ccb2d8973ef10e5ece541e8b624e1fb00",
+    "zh:b4608aab78b4dbb32c629595797107fc5a84d1b8f0682f183793d13837f0ecf0",
+    "zh:ed2c791c2354764b565f9ba4be7fc845c619c1a32cefadd3154a5665b312ab00",
+    "zh:f94ac0072a8545eebabf417bc0acbdc77c31c006ad8760834ee8ee5cdb64e743",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/cloudinit" {
+  version = "2.2.0"
+  hashes = [
+    "h1:siiI0wK6/jUDdA5P8ifTO0yc9YmXHml4hz5K9I9N+MA=",
+    "h1:tQLNREqesrdCQ/bIJnl0+yUK+XfdWzAG0wo4lp10LvM=",
+    "zh:76825122171f9ea2287fd27e23e80a7eb482f6491a4f41a096d77b666896ee96",
+    "zh:795a36dee548e30ca9c9d474af9ad6d29290e0a9816154ad38d55381cd0ab12d",
+    "zh:9200f02cb917fb99e44b40a68936fd60d338e4d30a718b7e2e48024a795a61b9",
+    "zh:a33cf255dc670c20678063aa84218e2c1b7a67d557f480d8ec0f68bc428ed472",
+    "zh:ba3c1b2cd0879286c1f531862c027ec04783ece81de67c9a3b97076f1ce7f58f",
+    "zh:bd575456394428a1a02191d2e46af0c00e41fd4f28cfe117d57b6aeb5154a0fb",
+    "zh:c68dd1db83d8437c36c92dc3fc11d71ced9def3483dd28c45f8640cfcd59de9a",
+    "zh:cbfe34a90852ed03cc074601527bb580a648127255c08589bc3ef4bf4f2e7e0c",
+    "zh:d6ffd7398c6d1f359b96f5b757e77b99b339fbb91df1b96ac974fe71bc87695c",
+    "zh:d9c15285f847d7a52df59e044184fb3ba1b7679fd0386291ed183782683d9517",
+    "zh:f7dd02f6d36844da23c9a27bb084503812c29c1aec4aba97237fec16860fdc8c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version = "2.6.0"
+  hashes = [
+    "h1:rGVucCeYAqklKupwoLVG5VPQTIkUhO7WGcw3WuHYrm8=",
+    "zh:0ac248c28acc1a4fd11bd26a85e48ab78dd6abf0f7ac842bf1cd7edd05ac6cf8",
+    "zh:3d32c8deae3740d8c5310136cc11c8afeffc350fbf88afaca0c34a223a5246f5",
+    "zh:4055a27489733d19ca7fa2dfce14d323fe99ae9dede7d0fea21ee6db0b9ca74b",
+    "zh:58a8ed39653fd4c874a2ecb128eccfa24c94266a00e349fd7fb13e22ad81f381",
+    "zh:6c81508044913f25083de132d0ff81d083732aba07c506cc2db05aa0cefcde2c",
+    "zh:7db5d18093047bfc4fe597f79610c0a281b21db0d61b0bacb3800585e976f814",
+    "zh:8269207b7422db99e7be80a5352d111966c3dfc7eb98511f11c8ff7b2e813456",
+    "zh:b1d7ababfb2374e72532308ff442cc906b79256b66b3fe7a98d42c68c4ddf9c5",
+    "zh:ca63e226cbdc964a5d63ef21189f059ce45c3fa4a5e972204d6916a9177d2b44",
+    "zh:d205a72d60e8cc362943d66f5bcdd6b6aaaa9aab2b89fd83bf6f1978ac0b1e4c",
+    "zh:db47dc579a0e68e5bfe3a61f2e950e6e2af82b1f388d1069de014a937962b56a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.2.3"
+  hashes = [
+    "h1:KmHz81iYgw9Xn2L3Carc2uAzvFZ1XsE7Js3qlVeC77k=",
+    "h1:aWp5iSUxBGgPv1UnV5yag9Pb0N+U1I0sZb38AXBFO8A=",
+    "zh:04f0978bb3e052707b8e82e46780c371ac1c66b689b4a23bbc2f58865ab7d5c0",
+    "zh:6484f1b3e9e3771eb7cc8e8bab8b35f939a55d550b3f4fb2ab141a24269ee6aa",
+    "zh:78a56d59a013cb0f7eb1c92815d6eb5cf07f8b5f0ae20b96d049e73db915b238",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8aa9950f4c4db37239bcb62e19910c49e47043f6c8587e5b0396619923657797",
+    "zh:996beea85f9084a725ff0e6473a4594deb5266727c5f56e9c1c7c62ded6addbb",
+    "zh:9a7ef7a21f48fabfd145b2e2a4240ca57517ad155017e86a30860d7c0c109de3",
+    "zh:a63e70ac052aa25120113bcddd50c1f3cfe61f681a93a50cea5595a4b2cc3e1c",
+    "zh:a6e8d46f94108e049ad85dbed60354236dc0b9b5ec8eabe01c4580280a43d3b8",
+    "zh:bb112ce7efbfcfa0e65ed97fa245ef348e0fd5bfa5a7e4ab2091a9bd469f0a9e",
+    "zh:d7bec0da5c094c6955efed100f3fe22fca8866859f87c025be1760feb174d6d9",
+    "zh:fb9f271b72094d07cef8154cd3d50e9aa818a0ea39130bc193132ad7b23076fd",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.1.1"
+  hashes = [
+    "h1:71sNUDvmiJcijsvfXpiLCz0lXIBSsEJjMxljt7hxMhw=",
+    "h1:Pctug/s/2Hg5FJqjYcTM0kPyx3AoYK1MpRWO0T9V2ns=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.3.2"
+  hashes = [
+    "h1:Fu0IKMy46WsO5Y6KfuH9IFkkuxZjE/gIcgtB7GWkTtc=",
+    "h1:H5V+7iXol/EHB2+BUMzGlpIiCOdV74H8YjzCxnSAWcg=",
+    "zh:038293aebfede983e45ee55c328e3fde82ae2e5719c9bd233c324cfacc437f9c",
+    "zh:07eaeab03a723d83ac1cc218f3a59fceb7bbf301b38e89a26807d1c93c81cef8",
+    "zh:427611a4ce9d856b1c73bea986d841a969e4c2799c8ac7c18798d0cc42b78d32",
+    "zh:49718d2da653c06a70ba81fd055e2b99dfd52dcb86820a6aeea620df22cd3b30",
+    "zh:5574828d90b19ab762604c6306337e6cd430e65868e13ef6ddb4e25ddb9ad4c0",
+    "zh:7222e16f7833199dabf1bc5401c56d708ec052b2a5870988bc89ff85b68a5388",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b1b2d7d934784d2aee98b0f8f07a8ccfc0410de63493ae2bf2222c165becf938",
+    "zh:b8f85b6a20bd264fcd0814866f415f0a368d1123cd7879c8ebbf905d370babc8",
+    "zh:c3813133acc02bbebddf046d9942e8ba5c35fc99191e3eb057957dafc2929912",
+    "zh:e7a41dbc919d1de800689a81c240c27eec6b9395564630764ebb323ea82ac8a9",
+    "zh:ee6d23208449a8eaa6c4f203e33f5176fa795b4b9ecf32903dffe6e2574732c2",
+  ]
+}
+
+provider "registry.terraform.io/rancher/rancher2" {
+  version = "1.24.0"
+  hashes = [
+    "h1:0YGvgpzfVYv/9fyHjzzsbKAMsGZyemcReT+Q+6jEjLc=",
+    "h1:XWrsT6bqmswE61stocRBu0CsuXPRHqs7xS30ktnM2Kg=",
+    "zh:0278e7eca669b10082c7c0fd2037449e325d5f63db5881fd1a9b0c1cdf3be0bc",
+    "zh:19ef195b8af98deb2789533b05edf3870d49cdf82d6e07d197e9579bd77a0ffd",
+    "zh:3b875842e04b8205f018b5fbf481c0cfb69e2d1aae8b4b70323b60b1d03d2a7b",
+    "zh:6b7d4d6bb9c15fe6af369216afcf78020fdfbfbdebac7b158c8a1cde1278f38b",
+    "zh:a72d6438b7adfcc2327357bb4137ad65117e87db5ec463d2d9ed4a414d111a5b",
+    "zh:ad057167ddb5fc2126700328d41ba899db963d653e214c94d4f48b6f1e7b71b4",
+    "zh:b11dcb4adee3bd5a6a9118fe75709f3fb16b646eb022e21a8ea54d58ba3ebbcd",
+    "zh:b3516d8531e45cd9084fd12c00b94a0163b8d2cca7571ff68a8fe999a85232a5",
+    "zh:bc192ac3c7e98d5ad9532dd81ed29eb63c82fe8472dfc86b2807ff6182c95264",
+    "zh:cea331226092db9d6b7d45739293f2484c8811213636b07ca7c94a5d3592a925",
+    "zh:f26a9ebadbee87588166e519e1d74d14483a8188acc7b5c61809efb3c72f82c8",
+    "zh:f6705e74b669538280e9f1c9bce57a296497d7f17a7231dc9aaf95b89b3668a2",
+  ]
+}
+
+provider "registry.terraform.io/rancher/rke" {
+  version = "1.3.1"
+  hashes = [
+    "h1:DpzEH9zLCMIsi0WVS0EiPAW+FDAsE3fdY5G82NoJMn0=",
+    "h1:t33Em/LUiDBka6aVAuq/KyWlPX+na9rOQp9X5RPKRiw=",
+    "zh:173866412d42f5b731cfd2394eccd285d45ce12f9badb200d54bae40b7f544ba",
+    "zh:678d0505ab60904d17f7167e1926b7cef13846282343ec0a302d2ff460c0cf2d",
+    "zh:6802203fdcad8f562b7927cc7b7e035240d820d542fff16771323db3fb451782",
+    "zh:792510a9515d08a67f69a2602ec3f3079c9500f8f1ac43ee1e38e528abcb7850",
+    "zh:97b9a10044026a489d090d8bd090042994fa77996b89026f4ec307b59f187f80",
+    "zh:b2cc7a62025125d0aea42be8909f93c0ff035506947b4f90e46e42c2581f81bf",
+    "zh:cf39fcc94ba1c25021eff01b38286e6d103e32be1431b410fb65ad8bdd83962b",
+  ]
+}

--- a/rke1-local-control-plane/README.md
+++ b/rke1-local-control-plane/README.md
@@ -1,0 +1,199 @@
+## Control plane usage:
+### Download and Install the Required RKE1 version
+RKE binary releases can be found at: https://github.com/rancher/rke/releases.
+  1. Download the appropriate binary
+  2. Give it executable permissions `chmod +x <your binary>`
+  3. Rename it to `rke`
+  4. Move it into your `PATH` so that it can be run in a shell terminal
+
+### Create AWS profile
+Create an AWS profile named `rancher-eng` and provide access keys
+```bash
+aws configure --profile rancher-eng
+```
+
+### Creating cluster resources
+Initialize terraform default workspace. This only needs to be run once to create the initial workspace environment:
+```bash
+cd control-plane
+terraform init
+```
+Update modules mentioned in root module from their respective source:
+```
+terraform get --update
+terraform init
+```
+
+AWS credentials are required so they can either be set in the env or on the command line before running the below commands
+
+Create k3s cluster with **mariadb** data store:
+
+```bash
+terraform apply
+```
+Creating the cluster resources takes about 10-15 minutes. After successfully running `apply` terraform will output information needed to connect to the rancher server.
+
+### Destroying cluster resources
+
+```bash
+terraform destroy
+```
+
+Destroying cluster resources takes about 10-15 minutes.
+
+### Configuration:
+Configuration changes should be done in `terraform.tfvars` to override default variable settings in `variables.tf`. The format of the `terraform.tfvars` file must be in done with key/value pairs.
+
+#### Example terraform.tfvars file:
+```
+ssh_keys = [<ssh keys to place on nodes>
+]
+ssh_key_path = "<private ssh keypath for connecting to nodes>"
+
+### General Settings ###
+aws_region             = "us-west-1"
+domain                 = "qa.rancher.space"
+random_prefix          = "test"
+
+### Rancher ###
+rancher_chart         = "latest"
+rancher_node_count    = 3
+rancher_instance_type = "m5.xlarge"
+rancher_password      = "<your rancher pass>"
+rancher_charts_branch = "dev-v2.6"
+rancher_image_tag     = "v2.6.7"
+rancher_version       = "2.6.7"
+
+### Monitoring ###
+monitoring_version               = "100.1.3+up19.0.3"
+install_monitoring               = true
+cattle_prometheus_metrics        = true
+monitoring_crd_chart_values_path = "./files/values/rancher_monitoring_crd_chart_values.yaml"
+monitoring_chart_values_path     = "./files/values/rancher_monitoring_chart_values.yaml"
+
+#### Misc Settings ####
+enable_secrets_encryption = false
+sensitive_token           = false
+
+### RKE1 ###
+k8s_distribution       = "rke1"
+install_k8s_version    = "v1.24.2-rancher1-1"
+install_docker_version = "20.10"
+
+### Certificates ###
+letsencrypt_email   = "<your email>"
+certmanager_version = "1.8.1"
+s3_instance_profile = "RancherK8SUnrestrictedCloudProviderRoleWithRoute53S3FullUS"
+
+```
+
+### Accessing Monitoring
+When doing load testing, it is highly likely that the hosts Rancher is running on will die, so attempting to proxy through Rancher to view Grafana is not possible. Monitoring runs on its own node so it wont go down when Rancher or its hosts do. Using `kubectl` Grafana (and anything monitoring related) will still be accessible:
+```bash
+kubectl port-forward -n cattle-monitoring-system deployment/rancher-monitoring-grafana 8443:3000
+```
+Then go to `http://127.0.0.1:8443` in a browser to connect back to the Grafana UI.
+The port `8443` can be adjusted as need for your local system.
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.23.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.2.3 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.1.1 |
+| <a name="provider_rancher2.admin"></a> [rancher2.admin](#provider\_rancher2.admin) | 1.24.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.3.2 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_aws_infra"></a> [aws\_infra](#module\_aws\_infra) | ../control-plane/modules/aws-infra | n/a |
+| <a name="module_install_common"></a> [install\_common](#module\_install\_common) | ../rancher-cluster-operations/install-common | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [local_file.cluster_yml](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+| [null_resource.rke](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.set_loglevel](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [rancher2_app_v2.rancher_monitoring](https://registry.terraform.io/providers/rancher/rancher2/latest/docs/resources/app_v2) | resource |
+| [rancher2_catalog_v2.rancher_charts_custom](https://registry.terraform.io/providers/rancher/rancher2/latest/docs/resources/catalog_v2) | resource |
+| [random_password.rancher_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [random_pet.identifier](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_route53_zone.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+| [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
+| [aws_subnets.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+| [local_file.kube_config](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | n/a | `string` | `"us-west-2"` | no |
+| <a name="input_cattle_prometheus_metrics"></a> [cattle\_prometheus\_metrics](#input\_cattle\_prometheus\_metrics) | Boolean variable that defines whether or not to enable the CATTLE\_PROMETHEUS\_METRICS env var for Rancher | `bool` | `true` | no |
+| <a name="input_certmanager_version"></a> [certmanager\_version](#input\_certmanager\_version) | Version of cert-manager to install | `string` | `"1.8.1"` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | n/a | `string` | `""` | no |
+| <a name="input_enable_audit_log"></a> [enable\_audit\_log](#input\_enable\_audit\_log) | (Optional) Boolean that determines if secrets-encryption should be enabled | `bool` | `false` | no |
+| <a name="input_enable_secrets_encryption"></a> [enable\_secrets\_encryption](#input\_enable\_secrets\_encryption) | (Optional) Boolean that determines if secrets-encryption should be enabled | `bool` | `false` | no |
+| <a name="input_install_certmanager"></a> [install\_certmanager](#input\_install\_certmanager) | Boolean that defines whether or not to install Cert-Manager | `bool` | `true` | no |
+| <a name="input_install_docker_version"></a> [install\_docker\_version](#input\_install\_docker\_version) | Version of Docker to install | `string` | `"20.10"` | no |
+| <a name="input_install_k8s_version"></a> [install\_k8s\_version](#input\_install\_k8s\_version) | Version of K8s to install | `string` | `""` | no |
+| <a name="input_install_monitoring"></a> [install\_monitoring](#input\_install\_monitoring) | Boolean that defines whether or not to install rancher-monitoring | `bool` | `true` | no |
+| <a name="input_install_rancher"></a> [install\_rancher](#input\_install\_rancher) | Boolean that defines whether or not to install Rancher | `bool` | `true` | no |
+| <a name="input_letsencrypt_email"></a> [letsencrypt\_email](#input\_letsencrypt\_email) | LetsEncrypt email address to use | `string` | `"none@none.com"` | no |
+| <a name="input_monitoring_chart_values_path"></a> [monitoring\_chart\_values\_path](#input\_monitoring\_chart\_values\_path) | Path to custom values.yaml for rancher-monitoring | `string` | `null` | no |
+| <a name="input_monitoring_crd_chart_values_path"></a> [monitoring\_crd\_chart\_values\_path](#input\_monitoring\_crd\_chart\_values\_path) | Path to custom values.yaml for rancher-monitoring | `string` | `null` | no |
+| <a name="input_monitoring_version"></a> [monitoring\_version](#input\_monitoring\_version) | Version of Monitoring v2 to install - Do not include the v prefix. | `string` | n/a | yes |
+| <a name="input_r53_domain"></a> [r53\_domain](#input\_r53\_domain) | DNS domain for Route53 zone (defaults to domain if unset) | `string` | `""` | no |
+| <a name="input_rancher_chart"></a> [rancher\_chart](#input\_rancher\_chart) | Helm chart to use for Rancher install | `string` | `"stable"` | no |
+| <a name="input_rancher_charts_branch"></a> [rancher\_charts\_branch](#input\_rancher\_charts\_branch) | The github branch for the desired Rancher chart version | `string` | `"release-v2.6"` | no |
+| <a name="input_rancher_charts_repo"></a> [rancher\_charts\_repo](#input\_rancher\_charts\_repo) | The URL for the desired Rancher charts | `string` | `"https://git.rancher.io/charts"` | no |
+| <a name="input_rancher_image"></a> [rancher\_image](#input\_rancher\_image) | n/a | `string` | `"rancher/rancher"` | no |
+| <a name="input_rancher_image_tag"></a> [rancher\_image\_tag](#input\_rancher\_image\_tag) | Rancher image tag to install, this can differ from rancher\_version which is the chart being used to install Rancher | `string` | `"master-head"` | no |
+| <a name="input_rancher_instance_type"></a> [rancher\_instance\_type](#input\_rancher\_instance\_type) | instance type used for the rancher servers | `string` | `"m5.xlarge"` | no |
+| <a name="input_rancher_loglevel"></a> [rancher\_loglevel](#input\_rancher\_loglevel) | A string specifying the loglevel to set on the rancher pods. One of: info, debug or trace. https://rancher.com/docs/rancher/v2.x/en/troubleshooting/logging/ | `string` | `"info"` | no |
+| <a name="input_rancher_node_count"></a> [rancher\_node\_count](#input\_rancher\_node\_count) | n/a | `number` | `1` | no |
+| <a name="input_rancher_password"></a> [rancher\_password](#input\_rancher\_password) | Password to set for admin user during bootstrap of Rancher Server, if not set random password will be generated | `string` | `""` | no |
+| <a name="input_rancher_version"></a> [rancher\_version](#input\_rancher\_version) | Version of Rancher to install - Do not include the v prefix. | `string` | n/a | yes |
+| <a name="input_random_prefix"></a> [random\_prefix](#input\_random\_prefix) | Prefix to be used with random name generation | `string` | `"rancher"` | no |
+| <a name="input_s3_instance_profile"></a> [s3\_instance\_profile](#input\_s3\_instance\_profile) | Optional: String that defines the name of the IAM Instance Profile that grants S3 access to the EC2 instances. | `string` | `""` | no |
+| <a name="input_sensitive_token"></a> [sensitive\_token](#input\_sensitive\_token) | Boolean that determines if the module should treat the generated Rancher Admin API Token as sensitive in the output. | `bool` | `true` | no |
+| <a name="input_ssh_key_path"></a> [ssh\_key\_path](#input\_ssh\_key\_path) | Path to the private SSH key file to be used for connecting to the node(s) | `string` | `null` | no |
+| <a name="input_ssh_keys"></a> [ssh\_keys](#input\_ssh\_keys) | SSH keys to inject into Rancher instances | `list(any)` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_cattle_prometheus_metrics"></a> [cattle\_prometheus\_metrics](#output\_cattle\_prometheus\_metrics) | n/a |
+| <a name="output_certmanager_version"></a> [certmanager\_version](#output\_certmanager\_version) | n/a |
+| <a name="output_install_certmanager"></a> [install\_certmanager](#output\_install\_certmanager) | n/a |
+| <a name="output_install_monitoring"></a> [install\_monitoring](#output\_install\_monitoring) | n/a |
+| <a name="output_install_rancher"></a> [install\_rancher](#output\_install\_rancher) | n/a |
+| <a name="output_kube_config_path"></a> [kube\_config\_path](#output\_kube\_config\_path) | n/a |
+| <a name="output_name"></a> [name](#output\_name) | n/a |
+| <a name="output_nodes_ids"></a> [nodes\_ids](#output\_nodes\_ids) | n/a |
+| <a name="output_nodes_info"></a> [nodes\_info](#output\_nodes\_info) | n/a |
+| <a name="output_nodes_private_ips"></a> [nodes\_private\_ips](#output\_nodes\_private\_ips) | n/a |
+| <a name="output_nodes_public_ips"></a> [nodes\_public\_ips](#output\_nodes\_public\_ips) | n/a |
+| <a name="output_rancher_admin_password"></a> [rancher\_admin\_password](#output\_rancher\_admin\_password) | n/a |
+| <a name="output_rancher_charts_branch"></a> [rancher\_charts\_branch](#output\_rancher\_charts\_branch) | n/a |
+| <a name="output_rancher_charts_repo"></a> [rancher\_charts\_repo](#output\_rancher\_charts\_repo) | n/a |
+| <a name="output_rancher_token"></a> [rancher\_token](#output\_rancher\_token) | n/a |
+| <a name="output_rancher_url"></a> [rancher\_url](#output\_rancher\_url) | n/a |
+| <a name="output_rancher_version"></a> [rancher\_version](#output\_rancher\_version) | n/a |
+| <a name="output_secrets_encryption"></a> [secrets\_encryption](#output\_secrets\_encryption) | n/a |
+| <a name="output_use_new_bootstrap"></a> [use\_new\_bootstrap](#output\_use\_new\_bootstrap) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/rke1-local-control-plane/data.tf
+++ b/rke1-local-control-plane/data.tf
@@ -1,0 +1,29 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "all" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+data "aws_security_group" "default" {
+  vpc_id = data.aws_vpc.default.id
+  name   = "default"
+}
+
+data "aws_route53_zone" "selected" {
+  name         = "${local.domain}."
+  private_zone = false
+}
+
+data "local_file" "kube_config" {
+  filename = local.kube_config
+  depends_on = [
+    null_resource.rke
+  ]
+}

--- a/rke1-local-control-plane/files/values/rancher_chart_values.tftpl
+++ b/rke1-local-control-plane/files/values/rancher_chart_values.tftpl
@@ -1,0 +1,24 @@
+hostname: ${rancher_hostname}
+ingress:
+  tls:
+%{ if !install_certmanager && install_byo_certs ~}
+    source: secret
+    secretName: tls-rancher-ingress
+%{ endif ~}
+%{ if install_certmanager ~}
+    source: letsEncrypt
+letsEncrypt:
+  email: ${letsencrypt_email}
+%{ endif ~}
+%{ if private_ca ~}
+privateCA: ${private_ca}
+%{ endif ~}
+rancherImage: ${rancher_image}
+rancherImageTag: ${rancher_image_tag}
+replicas: ${rancher_node_count}
+%{ if use_new_bootstrap ~}
+bootstrapPassword: ${rancher_password}
+%{ endif ~}
+extraEnv:
+- name: CATTLE_PROMETHEUS_METRICS
+  value: '${cattle_prometheus_metrics}'

--- a/rke1-local-control-plane/files/values/rancher_monitoring_chart_values.yaml
+++ b/rke1-local-control-plane/files/values/rancher_monitoring_chart_values.yaml
@@ -1,0 +1,50 @@
+alertmanager:
+  enabled: false
+grafana:
+  nodeSelector:
+    monitoring: 'yes'
+  tolerations:
+  - key: monitoring
+    operator: Exists
+    effect: NoSchedule
+prometheus:
+  prometheusSpec:
+    evaluationInterval: 1m
+    nodeSelector:
+      monitoring: 'yes'
+    resources:
+      limits:
+        memory: 5000Mi
+    retentionSize: 50GiB
+    scrapeInterval: 1m
+    tolerations:
+    - key: monitoring
+      operator: Exists
+      effect: NoSchedule
+prometheus-adapter:
+  nodeSelector:
+    monitoring: 'yes'
+  tolerations:
+  - key: monitoring
+    operator: Exists
+    effect: NoSchedule
+kube-state-metrics:
+  nodeSelector:
+    monitoring: 'yes'
+  tolerations:
+  - key: monitoring
+    operator: Exists
+    effect: NoSchedule
+prometheusOperator:
+  nodeSelector:
+    monitoring: 'yes'
+  tolerations:
+  - key: monitoring
+    operator: Exists
+    effect: NoSchedule
+global:
+  cattle:
+    clusterId: local
+    clusterName: local
+    systemDefaultRegistry: ''
+  systemDefaultRegistry: ''

--- a/rke1-local-control-plane/files/values/rancher_monitoring_crd_chart_values.yaml
+++ b/rke1-local-control-plane/files/values/rancher_monitoring_crd_chart_values.yaml
@@ -1,0 +1,6 @@
+global:
+  cattle:
+    clusterId: local
+    clusterName: local
+    systemDefaultRegistry: ''
+  systemDefaultRegistry: ''

--- a/rke1-local-control-plane/files/values/rke_cluster_yaml.tfpl
+++ b/rke1-local-control-plane/files/values/rke_cluster_yaml.tfpl
@@ -1,0 +1,38 @@
+nodes:
+%{ for i in range(length(addresses)) ~}
+- address: ${addresses[i]}
+  internal_address: ${private_addresses[i]}
+  role:
+  - controlplane
+  - worker
+  - etcd
+  user: ubuntu
+%{ endfor ~}
+%{ if dedicated_monitoring ~}
+- address: ${monitor_address}
+  internal_address: ${monitor_private_address}
+  role:
+  - worker
+  user: ubuntu
+  labels:
+    monitoring: "yes"
+  taints:
+  - key: monitoring
+    value: "yes"
+    effect: NoSchedule
+%{ endif ~}
+services:
+  etcd:
+    snapshot: true
+    retention: 24h
+    creation: 6h
+  kube-api:
+    secrets_encryption_config:
+      enabled: ${enable_secrets_encryption}
+    audit_log:
+      enabled: ${enable_audit_log}
+ssh_key_path: ${ssh_key_path}
+ssh_agent_auth: false
+ignore_docker_version: false
+kubernetes_version: ${kubernetes_version}
+cluster_name: local

--- a/rke1-local-control-plane/main.tf
+++ b/rke1-local-control-plane/main.tf
@@ -1,0 +1,208 @@
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    rancher2 = {
+      source = "rancher/rancher2"
+    }
+    helm = {
+      source = "hashicorp/helm"
+    }
+  }
+  backend "local" {
+    path = "rancher.tfstate"
+  }
+}
+
+resource "random_pet" "identifier" {
+  keepers = {
+  }
+  prefix = var.random_prefix
+  length = 1
+}
+
+locals {
+  aws_region               = var.aws_region
+  name                     = "${random_pet.identifier.id}-rke1"
+  identifier               = random_pet.identifier.id
+  domain                   = var.domain
+  use_new_bootstrap        = length(regexall("^([2-9]|\\d{2,})\\.([6-9]|\\d{2,})\\.([0-9]|\\d{2,})", var.rancher_version)) > 0
+  install_common           = var.install_rancher || var.install_certmanager
+  install_monitoring       = local.install_common && var.install_monitoring && var.install_rancher
+  server_node_count        = local.install_monitoring ? (var.rancher_node_count + 1) : var.rancher_node_count
+  server_addresses         = slice(module.aws_infra.nodes_public_ips, 0, var.rancher_node_count)
+  server_private_addresses = slice(module.aws_infra.nodes_private_ips, 0, var.rancher_node_count)
+  monitor_address          = local.install_monitoring ? slice(module.aws_infra.nodes_public_ips, var.rancher_node_count, var.rancher_node_count + 1)[0] : null
+  monitor_private_address  = local.install_monitoring ? slice(module.aws_infra.nodes_private_ips, var.rancher_node_count, var.rancher_node_count + 1)[0] : null
+  rke_file_path            = "${path.module}/files/clusters"
+  cluster_yml              = "${local.rke_file_path}/${terraform.workspace}_cluster.yml"
+  kube_config              = "${local.rke_file_path}/kube_config_${terraform.workspace}_cluster.yml"
+  rancher_url              = local.install_monitoring ? module.install_common[0].rancher_url : ""
+  rancher_token            = local.install_monitoring ? module.install_common[0].rancher_token : ""
+  nodes_info = [for i in range(0, local.server_node_count) : {
+    id              = module.aws_infra.nodes_ids[i],
+    public_address  = module.aws_infra.nodes_public_ips[i],
+    private_address = module.aws_infra.nodes_private_ips[i]
+  }]
+
+}
+
+resource "random_password" "rancher_password" {
+  length           = 16
+  special          = true
+  override_special = "_%@"
+}
+
+module "aws_infra" {
+  source = "../control-plane/modules/aws-infra"
+
+  vpc_id                 = data.aws_vpc.default.id
+  create_external_nlb    = true
+  name                   = local.name
+  user                   = data.aws_caller_identity.current.user_id
+  ssh_keys               = var.ssh_keys
+  ssh_key_path           = var.ssh_key_path
+  server_instance_type   = var.rancher_instance_type
+  server_node_count      = local.server_node_count
+  install_docker_version = var.install_docker_version
+  domain                 = local.domain
+  r53_domain             = var.r53_domain
+  s3_instance_profile    = var.s3_instance_profile
+}
+
+resource "local_file" "cluster_yml" {
+  filename = local.cluster_yml
+  content = templatefile("${path.module}/files/values/rke_cluster_yaml.tfpl", {
+    addresses                 = local.server_addresses,
+    private_addresses         = local.server_private_addresses,
+    dedicated_monitoring      = local.install_monitoring,
+    monitor_address           = local.monitor_address,
+    monitor_private_address   = local.monitor_private_address,
+    enable_secrets_encryption = var.enable_secrets_encryption,
+    enable_audit_log          = var.enable_audit_log,
+    ssh_key_path              = var.ssh_key_path,
+    kubernetes_version        = var.install_k8s_version
+  })
+
+  depends_on = [
+    module.aws_infra
+  ]
+}
+
+resource "null_resource" "rke" {
+  triggers = {
+    "rke_file_path" = local.rke_file_path
+    "cluster_yml"   = local.cluster_yml
+    "kube_config"   = local.kube_config
+  }
+  provisioner "local-exec" {
+    command = "rke up --config ${local.cluster_yml}"
+  }
+  provisioner "local-exec" {
+    when    = destroy
+    command = "rke remove --force --config ${self.triggers.cluster_yml}; rm -rf ${self.triggers.rke_file_path}"
+    environment = {
+      rke_file_path = self.triggers.rke_file_path
+      cluster_yml   = self.triggers.cluster_yml
+      kube_config   = self.triggers.kube_config
+    }
+  }
+  depends_on = [
+    local_file.cluster_yml
+  ]
+}
+
+module "install_common" {
+  count  = local.install_common ? 1 : 0
+  source = "../rancher-cluster-operations/install-common"
+  providers = {
+    rancher2 = rancher2.bootstrap
+  }
+
+  kube_config_path = data.local_file.kube_config.filename
+
+  subdomain           = local.name
+  domain              = local.domain
+  install_certmanager = var.install_certmanager
+  install_rancher     = var.install_rancher
+  rancher_version     = var.rancher_version
+  certmanager_version = var.certmanager_version
+
+  helm_rancher_chart_values_path = "${path.module}/files/values/rancher_chart_values.tftpl"
+  letsencrypt_email              = var.letsencrypt_email
+  rancher_image                  = var.rancher_image
+  rancher_image_tag              = var.rancher_image_tag
+  rancher_password               = var.rancher_password
+  use_new_bootstrap              = local.use_new_bootstrap
+  rancher_node_count             = var.rancher_node_count
+  cattle_prometheus_metrics      = var.cattle_prometheus_metrics
+
+  depends_on = [
+    null_resource.rke
+  ]
+}
+
+resource "null_resource" "set_loglevel" {
+  count = var.install_rancher && var.rancher_loglevel != "info" ? 1 : 0
+  provisioner "local-exec" {
+    interpreter = [
+      "bash", "-c"
+    ]
+    command = <<-EOT
+    kubectl --kubeconfig <(echo $KUBECONFIG | base64 --decode) -n cattle-system get pods -l app=rancher --no-headers -o custom-columns=name:.metadata.name | while read rancherpod; do kubectl --kubeconfig <(echo $KUBECONFIG | base64 --decode) -n cattle-system exec $rancherpod -c rancher -- loglevel --set ${var.rancher_loglevel}; done
+    EOT
+    environment = {
+      KUBECONFIG = base64encode(file(data.local_file.kube_config.content))
+    }
+  }
+
+  depends_on = [
+    module.install_common
+  ]
+}
+
+resource "rancher2_catalog_v2" "rancher_charts_custom" {
+  count    = local.install_monitoring ? 1 : 0
+  provider = rancher2.admin
+
+  cluster_id = "local"
+  name       = "rancher-charts-custom"
+  git_repo   = var.rancher_charts_repo
+  git_branch = var.rancher_charts_branch
+
+  provisioner "local-exec" {
+    command = <<-EOT
+    sleep 10
+    EOT
+  }
+
+  depends_on = [
+    # null_resource.set_loglevel
+    module.install_common
+  ]
+}
+
+resource "rancher2_app_v2" "rancher_monitoring" {
+  count    = local.install_monitoring ? 1 : 0
+  provider = rancher2.admin
+
+  cluster_id    = "local"
+  name          = "rancher-monitoring"
+  namespace     = "cattle-monitoring-system"
+  repo_name     = "rancher-charts-custom"
+  chart_name    = "rancher-monitoring"
+  chart_version = var.monitoring_version
+  values        = file(var.monitoring_chart_values_path)
+
+  depends_on = [
+    rancher2_catalog_v2.rancher_charts_custom
+  ]
+}

--- a/rke1-local-control-plane/outputs.tf
+++ b/rke1-local-control-plane/outputs.tf
@@ -1,0 +1,77 @@
+output "rancher_admin_password" {
+  value     = var.rancher_password
+  sensitive = true
+}
+
+output "rancher_url" {
+  value = local.rancher_url
+}
+
+output "rancher_token" {
+  value     = nonsensitive(local.rancher_token)
+  sensitive = false
+}
+
+output "install_rancher" {
+  value = var.install_rancher
+}
+
+output "install_certmanager" {
+  value = var.install_certmanager
+}
+
+output "install_monitoring" {
+  value = var.install_monitoring
+}
+
+output "certmanager_version" {
+  value = var.certmanager_version
+}
+
+output "rancher_charts_repo" {
+  value = var.install_monitoring ? var.rancher_charts_repo : null
+}
+
+output "rancher_charts_branch" {
+  value = var.install_monitoring ? var.rancher_charts_branch : null
+}
+
+output "rancher_version" {
+  value = var.rancher_version
+}
+
+output "use_new_bootstrap" {
+  value = local.use_new_bootstrap
+}
+
+output "kube_config_path" {
+  value = abspath(local.kube_config)
+}
+
+output "secrets_encryption" {
+  value = var.enable_secrets_encryption
+}
+
+output "cattle_prometheus_metrics" {
+  value = var.cattle_prometheus_metrics
+}
+
+output "name" {
+  value = local.name
+}
+
+output "nodes_ids" {
+  value = module.aws_infra.nodes_ids
+}
+
+output "nodes_public_ips" {
+  value = module.aws_infra.nodes_public_ips
+}
+
+output "nodes_private_ips" {
+  value = module.aws_infra.nodes_private_ips
+}
+
+output "nodes_info" {
+  value = local.nodes_info
+}

--- a/rke1-local-control-plane/provider.tf
+++ b/rke1-local-control-plane/provider.tf
@@ -1,0 +1,31 @@
+provider "aws" {
+  region  = local.aws_region
+  profile = "rancher-eng"
+}
+
+provider "aws" {
+  region  = local.aws_region
+  profile = "rancher-eng"
+  alias   = "r53"
+}
+
+provider "rancher2" {
+  alias     = "bootstrap"
+  api_url   = "https://${local.name}.${local.domain}"
+  insecure  = false
+  bootstrap = true
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = abspath(local.kube_config)
+  }
+}
+
+provider "rancher2" {
+  alias     = "admin"
+  api_url   = local.rancher_url
+  token_key = local.rancher_token
+  insecure  = false
+  timeout   = "300s"
+}

--- a/rke1-local-control-plane/variables.tf
+++ b/rke1-local-control-plane/variables.tf
@@ -1,0 +1,179 @@
+variable "install_docker_version" {
+  type        = string
+  default     = "20.10"
+  description = "Version of Docker to install"
+}
+
+variable "install_k8s_version" {
+  type        = string
+  default     = ""
+  description = "Version of K8s to install"
+}
+
+variable "install_rancher" {
+  type        = bool
+  default     = true
+  description = "Boolean that defines whether or not to install Rancher"
+}
+
+variable "rancher_version" {
+  type        = string
+  description = "Version of Rancher to install - Do not include the v prefix."
+}
+
+variable "rancher_loglevel" {
+  type        = string
+  description = "A string specifying the loglevel to set on the rancher pods. One of: info, debug or trace. https://rancher.com/docs/rancher/v2.x/en/troubleshooting/logging/"
+  default     = "info"
+}
+
+variable "cattle_prometheus_metrics" {
+  default     = true
+  type        = bool
+  description = "Boolean variable that defines whether or not to enable the CATTLE_PROMETHEUS_METRICS env var for Rancher"
+}
+
+variable "install_monitoring" {
+  type        = bool
+  default     = true
+  description = "Boolean that defines whether or not to install rancher-monitoring"
+}
+
+variable "monitoring_version" {
+  type        = string
+  description = "Version of Monitoring v2 to install - Do not include the v prefix."
+}
+
+variable "monitoring_crd_chart_values_path" {
+  type        = string
+  default     = null
+  description = "Path to custom values.yaml for rancher-monitoring"
+}
+
+variable "monitoring_chart_values_path" {
+  type        = string
+  default     = null
+  description = "Path to custom values.yaml for rancher-monitoring"
+}
+
+variable "rancher_instance_type" {
+  default     = "m5.xlarge"
+  type        = string
+  description = "instance type used for the rancher servers"
+}
+
+variable "install_certmanager" {
+  default     = true
+  type        = bool
+  description = "Boolean that defines whether or not to install Cert-Manager"
+}
+
+variable "certmanager_version" {
+  type        = string
+  default     = "1.8.1"
+  description = "Version of cert-manager to install"
+}
+
+variable "s3_instance_profile" {
+  default     = ""
+  type        = string
+  description = "Optional: String that defines the name of the IAM Instance Profile that grants S3 access to the EC2 instances."
+}
+
+variable "ssh_keys" {
+  type        = list(any)
+  default     = []
+  description = "SSH keys to inject into Rancher instances"
+}
+
+variable "ssh_key_path" {
+  default     = null
+  type        = string
+  description = "Path to the private SSH key file to be used for connecting to the node(s)"
+}
+
+variable "rancher_image" {
+  type    = string
+  default = "rancher/rancher"
+}
+
+variable "rancher_image_tag" {
+  type        = string
+  default     = "master-head"
+  description = "Rancher image tag to install, this can differ from rancher_version which is the chart being used to install Rancher"
+}
+
+variable "rancher_node_count" {
+  type    = number
+  default = 1
+}
+
+variable "rancher_password" {
+  type        = string
+  default     = ""
+  description = "Password to set for admin user during bootstrap of Rancher Server, if not set random password will be generated"
+}
+
+variable "random_prefix" {
+  type        = string
+  default     = "rancher"
+  description = "Prefix to be used with random name generation"
+}
+
+variable "rancher_chart" {
+  type        = string
+  default     = "stable"
+  description = "Helm chart to use for Rancher install"
+}
+
+variable "rancher_charts_repo" {
+  type        = string
+  default     = "https://git.rancher.io/charts"
+  description = "The URL for the desired Rancher charts"
+}
+
+variable "rancher_charts_branch" {
+  type        = string
+  default     = "release-v2.6"
+  description = "The github branch for the desired Rancher chart version"
+}
+
+variable "letsencrypt_email" {
+  type        = string
+  default     = "none@none.com"
+  description = "LetsEncrypt email address to use"
+}
+
+variable "aws_region" {
+  type    = string
+  default = "us-west-2"
+}
+
+variable "domain" {
+  type    = string
+  default = ""
+}
+
+variable "r53_domain" {
+  type        = string
+  default     = ""
+  description = "DNS domain for Route53 zone (defaults to domain if unset)"
+}
+
+variable "sensitive_token" {
+  type        = bool
+  default     = true
+  description = "Boolean that determines if the module should treat the generated Rancher Admin API Token as sensitive in the output."
+}
+
+variable "enable_secrets_encryption" {
+  type        = bool
+  default     = false
+  description = "(Optional) Boolean that determines if secrets-encryption should be enabled"
+}
+
+variable "enable_audit_log" {
+  type        = bool
+  default     = false
+  description = "(Optional) Boolean that determines if secrets-encryption should be enabled"
+}

--- a/rke1-local-control-plane/versions.tf
+++ b/rke1-local-control-plane/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 1.0"
+}


### PR DESCRIPTION
This module is useful for when the terraform-rke-provider does not yet support the latest RKE1 version.

Example .tfvars:
```
ssh_keys = [<ssh keys to place on nodes>
]
ssh_key_path = "<private ssh keypath for connecting to nodes>"

### General Settings ###
aws_region             = "us-west-1"
domain                 = "qa.rancher.space"
random_prefix          = "test"

### Rancher ###
rancher_chart         = "latest"
rancher_node_count    = 3
rancher_instance_type = "m5.xlarge"
rancher_password      = "<your rancher pass>"
rancher_charts_branch = "dev-v2.6"
rancher_image_tag     = "v2.6.7"
rancher_version       = "2.6.7"

### Monitoring ###
monitoring_version               = "100.1.3+up19.0.3"
install_monitoring               = true
cattle_prometheus_metrics        = true
monitoring_crd_chart_values_path = "./files/values/rancher_monitoring_crd_chart_values.yaml"
monitoring_chart_values_path     = "./files/values/rancher_monitoring_chart_values.yaml"

#### Misc Settings ####
enable_secrets_encryption = false
sensitive_token           = false

### RKE1 ###
k8s_distribution       = "rke1"
install_k8s_version    = "v1.24.2-rancher1-1"
install_docker_version = "20.10"

### Certificates ###
letsencrypt_email   = "<your email>"
certmanager_version = "1.8.1"
s3_instance_profile = "RancherK8SUnrestrictedCloudProviderRoleWithRoute53S3FullUS"

```