### PR TITLE
Use dl.k8s.io for getting kubectl

### DIFF
--- a/cluster-with-nodes/files/server_userdata.tmpl
+++ b/cluster-with-nodes/files/server_userdata.tmpl
@@ -62,7 +62,7 @@ runcmd:
   #- curl -s https://raw.githubusercontent.com/rancher/k3d/master/install.sh | bash
   - wget https://github.com/Oats87/k3d/releases/download/network1/k3d-linux-amd64 -O /usr/local/bin/k3d
   - chmod +x /usr/local/bin/k3d
-  - curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+  - curl -LO https://dl.k8s.io/release/`curl -sL https://dl.k8s.io/release/stable.txt`/bin/linux/amd64/kubectl
   - chmod +x ./kubectl
   - mv ./kubectl /usr/local/bin/kubectl
   - sleep 5

--- a/clusters/files/server_userdata.tmpl
+++ b/clusters/files/server_userdata.tmpl
@@ -51,7 +51,7 @@ runcmd:
 # k3d v4.4.5 uses k3s v1.21.1+k3s1 by default to avoid https://k3d.io/faq/faq/#solved-nodes-fail-to-start-or-get-stuck-in-notready-state-with-log-nf_conntrack_max-permission-denied
 - wget https://github.com/rancher/k3d/releases/download/${k3d_version}/k3d-linux-amd64 -O /usr/local/bin/k3d
 - chmod +x /usr/local/bin/k3d
-- curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+- curl -LO https://dl.k8s.io/release/`curl -sL https://dl.k8s.io/release/stable.txt`/bin/linux/amd64/kubectl
 - chmod +x ./kubectl
 - mv ./kubectl /usr/local/bin/kubectl
 - sleep 5


### PR DESCRIPTION
The GCS bucket will be deprecated in the future. This URL is the currently documented source.